### PR TITLE
Centralize toast notifications

### DIFF
--- a/composables/useNotification.ts
+++ b/composables/useNotification.ts
@@ -1,0 +1,12 @@
+import { useToast } from '~/composables/useToast'
+import type { MessageType } from '~/types/message-type'
+
+export function useNotification() {
+  const toast = useToast()
+
+  const showNotification = (message: string, type: MessageType = 'info'): void => {
+    toast.add({ message, type })
+  }
+
+  return { showNotification }
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -7,6 +7,7 @@
     <!-- Main Page Content -->
     <main class="pb-20"> <!-- Add padding-bottom to prevent content overlap with fixed player -->
       <slot />
+      <LazyLayoutToastContainer />
     </main>
 
   </div>

--- a/pages/albums/[id].vue
+++ b/pages/albums/[id].vue
@@ -4,7 +4,7 @@ import type { Track } from '~/types/track';
 import type { Playlist } from '~/types/playlist';
 import type { MessageType } from '~/types/message-type';
 import { usePlayerStore } from '~/stores/player';
-import type { NotificationMessage } from '~/types/notification-message';
+import { useNotification } from '~/composables/useNotification';
 import type { QueueContext } from '~/stores/player';
 import { resolveCoverArtUrl } from '~/utils/formatters';
 
@@ -26,7 +26,7 @@ const albumId = computed(() => route.params.id as string);
 const selectedTrackForPlaylist = ref<Track | null>(null);
 const isAddToPlaylistModalOpen = ref(false);
 const openMenuForTrackId = ref<string | null>(null);
-const notification = ref<NotificationMessage>({ message: '', type: 'info', visible: false });
+const { showNotification } = useNotification();
 const isAddAlbumToPlaylistModalOpen = ref(false);
 // Template ref for OptionsMenu
 const albumOptionsMenuRef = ref<InstanceType<typeof OptionsMenu> | null>(null);
@@ -40,14 +40,6 @@ const selectedTrackForEdit = ref<Track | null>(null);
 const isEditLyricsModalOpen = ref(false);
 const selectedTrackForLyrics = ref<Track | null>(null);
 
-// Simple notification system
-const showNotification = (message: string, type: MessageType = 'info') => {
-  notification.value = { message, type, visible: true };
-  // Auto-hide after 3 seconds
-  setTimeout(() => {
-    notification.value.visible = false;
-  }, 3000);
-};
 
 // Apply the sidebar layout
 definePageMeta({
@@ -571,17 +563,5 @@ const onAlbumUpdateError = (errorMessage: string): void => {
       </div>
     </div>
 
-    <!-- Global Notification -->
-    <div v-if="notification.visible" class="toast toast-top toast-center min-w-max">
-      <div class="flex items-center">
-        <Icon :name="notification.type === 'success' ? 'material-symbols:check-circle-outline' :
-          notification.type === 'error' ? 'material-symbols:error-outline' :
-            'material-symbols:info-outline'" class="w-6 h-6 mr-2" />
-        <span>{{ notification.message }}</span>
-        <button @click="notification.visible = false" class="ml-2 p-1">
-          <Icon name="material-symbols:close" class="w-4 h-4" />
-        </button>
-      </div>
-    </div>
   </div>
 </template>

--- a/pages/albums/index.vue
+++ b/pages/albums/index.vue
@@ -73,26 +73,11 @@
   <EditAlbumModal v-if="selectedAlbumForEdit" :album="selectedAlbumForEdit" :open="isEditAlbumModalOpen"
     @close="closeEditAlbumModal" @albumUpdated="handleAlbumUpdated" @updateError="handleUpdateError" />
 
-  <!-- Simple Notification Component -->
-  <div v-if="notification.visible" class="fixed bottom-4 right-4 p-4 rounded-lg shadow-lg z-50 max-w-md" :class="{
-    'bg-success text-success-content': notification.type === 'success',
-    'bg-error text-error-content': notification.type === 'error',
-    'bg-info text-info-content': notification.type === 'info'
-  }">
-    <div class="flex items-center">
-      <Icon :name="notification.type === 'success' ? 'material-symbols:check-circle-outline' :
-        notification.type === 'error' ? 'material-symbols:error-outline' :
-          'material-symbols:info-outline'" class="w-6 h-6 mr-2" />
-      <span>{{ notification.message }}</span>
-      <button @click="notification.visible = false" class="ml-2 p-1">
-        <Icon name="material-symbols:close" class="w-4 h-4" />
-      </button>
-    </div>
-  </div>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted, computed, watch, onUnmounted } from '#imports';
+import { useNotification } from '~/composables/useNotification';
 import { storeToRefs } from 'pinia';
 import { useSearchStore } from '~/stores/search-store';
 import { useRoute, useRouter } from 'vue-router';
@@ -112,6 +97,7 @@ const playerStore = usePlayerStore();
 const searchStore = useSearchStore();
 const { searchQuery } = storeToRefs(searchStore);
 const { getCoverArtUrl } = useCoverArt();
+const { showNotification } = useNotification();
 
 // --- State for Album Details and Playback ---
 const currentAlbum = ref<Album | null>(null);
@@ -124,7 +110,6 @@ const isAddToPlaylistModalOpen = ref<boolean>(false);
 const selectedAlbumForEdit = ref<Album | null>(null);
 const isEditAlbumModalOpen = ref<boolean>(false);
 const playlists = ref<any[]>([]);
-const notification = ref<{ message: string; type: 'success' | 'error' | 'info'; visible: boolean }>({ message: '', type: 'info', visible: false });
 
 // --- State for Albums List Display ---
 const route = useRoute();
@@ -317,14 +302,6 @@ const goToAlbum = (albumId: string): void => {
   navigateTo(`/albums/${albumId}`);
 };
 
-// Simple notification system
-const showNotification = (message: string, type: 'success' | 'error' | 'info' = 'info'): void => {
-  notification.value = { message, type, visible: true };
-  // Auto-hide after 3 seconds
-  setTimeout(() => {
-    notification.value.visible = false;
-  }, 3000);
-};
 
 // Fetch user's playlists
 async function fetchPlaylists(): Promise<void> {

--- a/pages/library.vue
+++ b/pages/library.vue
@@ -115,25 +115,6 @@
   </div>
   
   <!-- Simple Notification Component -->
-  <div v-if="notification.visible" 
-       class="fixed bottom-4 right-4 p-4 rounded-lg shadow-lg z-50 max-w-md"
-       :class="{
-         'bg-success text-success-content': notification.type === 'success',
-         'bg-error text-error-content': notification.type === 'error',
-         'bg-info text-info-content': notification.type === 'info'
-       }">
-    <div class="flex items-center">
-      <Icon 
-        :name="notification.type === 'success' ? 'material-symbols:check-circle-outline' : 
-              notification.type === 'error' ? 'material-symbols:error-outline' : 
-              'material-symbols:info-outline'" 
-        class="w-6 h-6 mr-2" />
-      <span>{{ notification.message }}</span>
-      <button @click="notification.visible = false" class="ml-2 p-1">
-        <Icon name="material-symbols:close" class="w-4 h-4" />
-      </button>
-    </div>
-  </div>
 
    <!-- Global Audio Player Placeholder - To be implemented in layout -->
    <!-- <AudioPlayer /> -->
@@ -141,6 +122,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from '#imports'
+import { useNotification } from '~/composables/useNotification'
 import { usePlayerStore } from '~/stores/player';
 import { useTrackArtists } from '~/composables/useTrackArtists';
 import type { Track } from '~/types/track'; // Update import path for Track type
@@ -163,7 +145,7 @@ const albumIdLoading = ref<string | null>(null);
 const selectedAlbumForPlaylist = ref<Album | null>(null);
 const isAddToPlaylistModalOpen = ref<boolean>(false);
 const playlists = ref<Playlist[]>([]);
-const notification = ref<{ message: string; type: 'success' | 'error' | 'info'; visible: boolean }>({ message: '', type: 'info', visible: false });
+const { showNotification } = useNotification();
 
 // Search State
 const searchQuery = ref('');
@@ -337,14 +319,6 @@ const navigateToAlbum = (albumId: string): void => {
   navigateTo(`/albums/${albumId}`);
 };
 
-// Simple notification system
-const showNotification = (message: string, type: 'success' | 'error' | 'info' = 'info'): void => {
-  notification.value = { message, type, visible: true };
-  // Auto-hide after 3 seconds
-  setTimeout(() => {
-    notification.value.visible = false;
-  }, 3000);
-};
 
 // Fetch user's playlists
 async function fetchPlaylists(): Promise<void> {

--- a/pages/playlists/[id].vue
+++ b/pages/playlists/[id].vue
@@ -130,11 +130,6 @@
       @update-error="handleEditModalUpdateError"
     />
 
-    <!-- Notification -->
-    <div v-if="notification.visible"
-      :class="['toast', notification.type === 'error' ? 'toast-error' : 'toast-success']">
-      {{ notification.message }}
-    </div>
   </div>
 </template>
 
@@ -144,7 +139,7 @@ import { usePlayerStore } from '~/stores/player';
 import TrackItem from '~/components/track/track-item.vue';
 import type { Playlist, PlaylistTrack } from '~/types/playlist';
 import type { Track } from '~/types/track';
-import type { NotificationMessage } from '~/types/notification-message';
+import { useNotification } from '~/composables/useNotification';
 import RemoveFromPlaylistModal from '~/components/modals/remove-from-playlist-modal.vue';
 import AddToPlaylistModal from '~/components/modals/add-to-playlist-modal.vue'; // Added
 import EditTrackModal from '~/components/modals/edit-track-modal.vue';
@@ -176,12 +171,7 @@ const trackForAddToPlaylistModal = ref<Track | null>(null); // Added
 // State for EditTrackModal
 const isEditTrackModalOpen = ref(false);
 const selectedTrackForEdit = ref<Track | null>(null);
-const notification = ref<NotificationMessage>({ message: '', type: 'info', visible: false });
-
-function showNotification(message: string, type: 'success' | 'error' | 'info' = 'success'): void {
-  notification.value = { message, type, visible: true };
-  setTimeout(() => (notification.value.visible = false), 2500);
-}
+const { showNotification } = useNotification();
 
 /**
  * Fetch playlist details from API


### PR DESCRIPTION
## Summary
- create `useNotification` composable that wraps `useToast`
- add toast container to default layout
- replace local notification logic in pages with shared composable

## Testing
- `pnpm test` *(fails: fetch to registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685959b8aa248322af5d45f697051e43