### PR TITLE
Centralize splitArtistString utility

### DIFF
--- a/server/api/albums/[id].put.ts
+++ b/server/api/albums/[id].put.ts
@@ -8,20 +8,8 @@ import { useCoverArt } from '~/composables/use-cover-art';
 import { v4 as uuidv4 } from 'uuid'; // For generating unique filenames
 import { eq, and } from 'drizzle-orm';
 import { getUserFromEvent } from '~/server/utils/auth';
+import { splitArtistString } from '~/server/utils/artist-utils';
 
-// Utility function to split artist strings (copied from scanner utils, ideally shared)
-function splitArtistString(artistString: string): string[] {
-  if (!artistString || typeof artistString !== 'string') return [];
-  const trimmedArtist = artistString.trim();
-  if (!trimmedArtist) return [];
-  const separators = [', ', '; ', ' feat. ', ' featuring ', ' ft. ', ' with ', ' & ', ' and ', ' x '];
-  for (const separator of separators) {
-    if (trimmedArtist.includes(separator)) {
-      return trimmedArtist.split(separator).map(part => part.trim()).filter(part => part.length > 0);
-    }
-  }
-  return [trimmedArtist];
-}
 
 // Define the expected request body type
 // Request body will be FormData, so we'll parse fields individually

--- a/server/utils/artist-utils.ts
+++ b/server/utils/artist-utils.ts
@@ -1,0 +1,39 @@
+/**
+ * Splits a combined artist string into individual artist names.
+ * Handles various formats like "Artist A, Artist B", "Artist X feat. Artist Y", etc.
+ * @param artistString The combined artist string to split
+ * @returns Array of individual artist names
+ */
+export function splitArtistString(artistString: string): string[] {
+  if (!artistString || typeof artistString !== 'string') return [];
+
+  // Trim the input string
+  const trimmedArtist = artistString.trim();
+  if (!trimmedArtist) return [];
+
+  // Common separators in artist strings
+  const separators = [
+    ', ', // Standard comma separation (Eminem, Dr. Dre)
+    '; ', // Semicolon separation
+    ' feat. ', // Featured artist notation
+    ' featuring ', // Full featured artist notation
+    ' ft. ', // Alternative featured artist notation
+    ' with ', // Collaboration notation
+    ' & ', // Ampersand separation
+    ' and ', // Text 'and' separation
+    ' x ', // Modern collaboration notation (Artist x Artist)
+  ];
+
+  // First, try splitting with common separators
+  for (const separator of separators) {
+    if (trimmedArtist.includes(separator)) {
+      return trimmedArtist
+        .split(separator)
+        .map(part => part.trim())
+        .filter(part => part.length > 0);
+    }
+  }
+
+  // If no separator was found, return the original artist name as a single-element array
+  return [trimmedArtist];
+}

--- a/server/utils/scanner/index.ts
+++ b/server/utils/scanner/index.ts
@@ -12,45 +12,8 @@ import type { TrackFileMetadata } from '~/server/utils/scanner/db-operations';
 import { TrackMetadata } from '~/server/utils/scanner/types';
 import { getReleaseInfoWithTags, searchReleaseByTitleAndArtist, getReleaseTracklist } from '~/server/utils/musicbrainz';
 import { AlbumProcessStatus } from '~/types/enums/album-process-status';
+import { splitArtistString } from '~/server/utils/artist-utils';
 
-/**
- * Splits a combined artist string into individual artist names.
- * Handles various formats like "Artist A, Artist B", "Artist X feat. Artist Y", etc.
- * @param artistString The combined artist string to split
- * @returns Array of individual artist names
- */
-function splitArtistString(artistString: string): string[] {
-  if (!artistString || typeof artistString !== 'string') return [];
-  
-  // Trim the input string
-  const trimmedArtist = artistString.trim();
-  if (!trimmedArtist) return [];
-  
-  // Common separators in artist strings
-  const separators = [
-    ', ', // Standard comma separation (Eminem, Dr. Dre)
-    '; ', // Semicolon separation
-    ' feat. ', // Featured artist notation
-    ' featuring ', // Full featured artist notation
-    ' ft. ', // Alternative featured artist notation
-    ' with ', // Collaboration notation
-    ' & ', // Ampersand separation
-    ' and ', // Text 'and' separation
-    ' x ', // Modern collaboration notation (Artist x Artist)
-  ];
-  
-  // First, try splitting with common separators
-  for (const separator of separators) {
-    if (trimmedArtist.includes(separator)) {
-      return trimmedArtist.split(separator)
-        .map(part => part.trim())
-        .filter(part => part.length > 0);
-    }
-  }
-  
-  // If no separator was found, return the original artist name as a single-element array
-  return [trimmedArtist];
-}
 
 interface ScanLibraryParams {
   libraryId: string;


### PR DESCRIPTION
## Summary
- create `artist-utils.ts` with `splitArtistString`
- use the new util in scanner and album API

## Testing
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685959ba62cc8322afbe19f0151b875c