### PR TITLE
Import cover art helper

### DIFF
--- a/components/player/mini-player.vue
+++ b/components/player/mini-player.vue
@@ -71,14 +71,9 @@
 
 <script setup lang="ts">
 import { usePlayerStore } from '~/stores/player';
+import { resolveCoverArtUrl } from '~/utils/formatters';
 
 const playerStore = usePlayerStore();
-
-// Assuming resolveCoverArtUrl is globally available or will be made so.
-// If not, it needs to be imported or defined here.
-// For TypeScript to not complain, we can declare it if we are sure it will be available globally.
-// Otherwise, a more robust solution is to import it from its definition source.
-declare function resolveCoverArtUrl(path: string | undefined): string;
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- import `resolveCoverArtUrl` into `mini-player.vue`
- remove the old declaration

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_685959bc2e9c832284ab325d1fb12244