### PR TITLE
Add discovery playlists

### DIFF
--- a/layouts/sidebar-layout.vue
+++ b/layouts/sidebar-layout.vue
@@ -57,7 +57,8 @@
             <li><NuxtLink to="/artists" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="material-symbols:artist-outline" class="w-5 h-5" /> Artists</NuxtLink></li>
             <li><NuxtLink to="/genres" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="material-symbols:label-outline" class="w-5 h-5" /> Genres</NuxtLink></li>
             <li><NuxtLink to="/playlists" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="material-symbols:mood-outline" class="w-5 h-5" /> Playlists</NuxtLink></li>
-                        <li><NuxtLink to="/radio" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="ph:radio-fill" class="w-5 h-5" /> Radio</NuxtLink></li>
+            <li><NuxtLink to="/discovery" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="material-symbols:lightbulb-outline" class="w-5 h-5" /> Discover</NuxtLink></li>
+            <li><NuxtLink to="/radio" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="ph:radio-fill" class="w-5 h-5" /> Radio</NuxtLink></li>
           </ul>
       </nav>
 

--- a/pages/discovery/[id].vue
+++ b/pages/discovery/[id].vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="container mx-auto px-4 py-8 space-y-8 overflow-y-auto">
+    <div v-if="pending" class="text-center">
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+    <div v-else-if="error" class="alert alert-error shadow-lg flex items-center gap-2">
+      <Icon name="material-symbols:error-outline" class="w-6 h-6" />
+      <span>Failed to load playlist. Please try again later.</span>
+    </div>
+    <div v-else-if="playlist">
+      <div class="flex flex-col md:flex-row gap-8 items-start">
+        <div class="flex-shrink-0 w-48 h-48 md:w-64 md:h-64 relative group bg-base-300 rounded-lg overflow-hidden">
+          <div class="grid grid-cols-2 w-full h-full">
+            <div class="bg-base-200 aspect-square"></div>
+            <div class="bg-base-300 aspect-square"></div>
+            <div class="bg-base-200 aspect-square"></div>
+            <div class="bg-base-300 aspect-square"></div>
+          </div>
+        </div>
+        <div class="flex-1 flex flex-col justify-between gap-4">
+          <div>
+            <h1 class="text-3xl font-bold mb-2">{{ playlist.title }}</h1>
+            <p class="text-base-content/70">{{ formatTrackCount(playlist.tracks.length) }}</p>
+          </div>
+          <div class="flex gap-2 mt-4">
+            <button class="btn btn-primary gap-2" @click="playPlaylist" :disabled="!playlist.tracks.length">
+              <Icon name="material-symbols:play-arrow" class="w-6 h-6" />
+              Play
+            </button>
+          </div>
+        </div>
+      </div>
+      <div v-if="!playlist.tracks.length" class="flex flex-col items-center justify-center py-16 text-center">
+        <Icon name="material-symbols:music-note" class="w-16 h-16 text-primary mb-4" />
+        <h3 class="text-xl font-bold mb-2">No Tracks Yet</h3>
+      </div>
+      <div v-else>
+        <h2 class="text-2xl font-semibold my-4">Tracks</h2>
+        <div class="overflow-x-auto">
+          <table class="table w-full">
+            <tbody>
+              <TrackItem v-for="(pt, index) in playlist.tracks" :key="pt.discoveryPlaylistTrackId" :track="mapPlaylistTrack(pt)" :track-number="index + 1" :playlists="[]" @play-track="playTrackFromList" />
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRoute } from 'vue-router';
+import { usePlayerStore } from '~/stores/player';
+import TrackItem from '~/components/track/track-item.vue';
+import type { DiscoveryPlaylist, DiscoveryPlaylistTrack } from '~/types/discovery-playlist';
+import type { Track } from '~/types/track';
+import { usePageTitle } from '~/composables/page-defaults';
+
+definePageMeta({ layout: 'sidebar-layout' });
+
+const playerStore = usePlayerStore();
+const route = useRoute();
+const playlistId = computed((): string => route.params.id as string);
+
+const pending = ref(true);
+const error = ref(false);
+
+const { data: playlist, error: playlistError } = await useLazyFetch<DiscoveryPlaylist>(`/api/discovery-playlists/${playlistId.value}`);
+
+if (playlistError.value) {
+  error.value = true;
+  console.error('Failed to fetch discovery playlist:', playlistError.value);
+}
+
+watch(playlist.value, (newPlaylist: DiscoveryPlaylist | null) => {
+  if (newPlaylist) {
+    pending.value = false;
+    useSeoMeta({ title: usePageTitle('Discover | ' + newPlaylist.title) });
+  }
+});
+
+if (playlist.value) {
+  pending.value = false;
+  useSeoMeta({ title: usePageTitle('Discover | ' + playlist.value.title) });
+}
+
+function formatTrackCount(count: number): string {
+  return count === 1 ? '1 track' : `${count} tracks`;
+}
+
+function mapPlaylistTrack(pt: DiscoveryPlaylistTrack): Track {
+  return pt.track;
+}
+
+function playPlaylist(): void {
+  if (!playlist.value?.tracks.length) return;
+  const tracks = playlist.value.tracks.map(mapPlaylistTrack);
+  if (!tracks.length) return;
+  playerStore.loadQueue(tracks, { type: 'discovery', id: playlistId.value });
+  playerStore.playFromQueue(0);
+}
+
+function playTrackFromList(track: Track): void {
+  if (!playlist.value?.tracks.length) return;
+  const tracks = playlist.value.tracks.map(mapPlaylistTrack);
+  const idx = tracks.findIndex(t => t.trackId === track.trackId);
+  if (idx !== -1) {
+    playerStore.loadQueue(tracks, { type: 'discovery', id: playlistId.value });
+    playerStore.playFromQueue(idx);
+  }
+}
+</script>

--- a/pages/discovery/index.vue
+++ b/pages/discovery/index.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="w-full h-[calc(100vh+5rem)] p-4 bg-base-200 overflow-y-auto">
+    <div class="flex justify-between items-center mb-2 sticky top-0 bg-base-200/80 backdrop-blur py-2 z-10">
+      <div class="form-control">
+        <input type="text" placeholder="Search Discovery Playlists..." class="input input-bordered w-72 md:w-96" v-model="searchQuery" />
+      </div>
+    </div>
+
+    <div v-if="pending" class="flex justify-center items-center py-12">
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+
+    <div v-else-if="error" class="alert alert-error mt-4">
+      <Icon name="material-symbols:error-outline" class="w-6 h-6" />
+      <span>Failed to load playlists. Please try again later.</span>
+    </div>
+
+    <div v-else-if="!playlists || playlists.length === 0" class="flex flex-col items-center justify-center py-16 text-center">
+      <Icon name="material-symbols:lightbulb-outline" class="w-20 h-20 text-primary mb-4" />
+      <h3 class="text-xl font-bold mb-2">No Discovery Playlists Yet</h3>
+      <p class="text-base-content/70 mb-6 max-w-md">Generate discovery playlists to find new music.</p>
+    </div>
+
+    <div v-else class="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 mt-4">
+      <div v-for="playlist in filteredPlaylists" :key="playlist.discoveryPlaylistId" class="card bg-base-100 shadow-xl hover:shadow-2xl transition-all duration-300 cursor-pointer group" @click="navigateToPlaylist(playlist.discoveryPlaylistId)">
+        <figure class="relative pt-[100%] bg-base-300 overflow-hidden">
+          <div class="absolute inset-0 flex items-center justify-center">
+            <div class="grid grid-cols-2 w-full h-full">
+              <div class="bg-base-200 aspect-square"></div>
+              <div class="bg-base-300 aspect-square"></div>
+              <div class="bg-base-200 aspect-square"></div>
+              <div class="bg-base-300 aspect-square"></div>
+            </div>
+          </div>
+          <div class="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all duration-300 flex items-center justify-center opacity-0 group-hover:opacity-100">
+            <button class="btn btn-circle btn-primary" @click.stop="playPlaylist(playlist.discoveryPlaylistId)">
+              <Icon name="material-symbols:play-arrow" class="w-8 h-8" />
+            </button>
+          </div>
+        </figure>
+
+        <div class="card-body p-4">
+          <h2 class="card-title text-base truncate">{{ playlist.title }}</h2>
+          <p class="text-sm text-base-content/70">{{ formatTrackCount(playlist.trackCount) }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { usePlayerStore } from '~/stores/player';
+import type { DiscoveryPlaylist } from '~/types/discovery-playlist';
+import { usePageTitle } from '~/composables/page-defaults';
+
+useSeoMeta({
+  title: usePageTitle('Discover')
+});
+
+const searchQuery = ref('');
+const { data: playlists, pending, error, refresh } = useLazyFetch<DiscoveryPlaylist[]>('/api/discovery-playlists');
+
+const playerStore = usePlayerStore();
+
+const filteredPlaylists = computed(() => {
+  if (!playlists.value) return [];
+  if (!searchQuery.value.trim()) return playlists.value;
+  const query = searchQuery.value.toLowerCase();
+  return playlists.value.filter(p => p.title.toLowerCase().includes(query));
+});
+
+const navigateToPlaylist = (id: string) => {
+  navigateTo(`/discovery/${id}`);
+};
+
+const playPlaylist = async (id: string) => {
+  try {
+    const playlistWithTracks = await $fetch<any>(`/api/discovery-playlists/${id}`);
+    if (!playlistWithTracks.tracks || playlistWithTracks.tracks.length === 0) return;
+    playerStore.loadQueue(playlistWithTracks.tracks);
+    playerStore.playFromQueue(0);
+  } catch (err) {
+    console.error('Error playing discovery playlist:', err);
+  }
+};
+
+const formatTrackCount = (count: number): string => {
+  return count === 1 ? '1 track' : `${count} tracks`;
+};
+
+onMounted(() => {
+  refresh();
+});
+
+definePageMeta({
+  layout: 'sidebar-layout'
+});
+</script>

--- a/server/api/discovery-playlists/[id]/index.get.ts
+++ b/server/api/discovery-playlists/[id]/index.get.ts
@@ -1,0 +1,108 @@
+import { defineEventHandler, getRouterParam } from 'h3';
+import { db } from '~/server/db';
+import {
+  discoveryPlaylists,
+  discoveryPlaylistTracks,
+  tracks,
+  albums,
+  artists,
+} from '~/server/db/schema';
+import { and, eq, asc } from 'drizzle-orm';
+import { getUserFromEvent } from '~/server/utils/auth';
+
+export default defineEventHandler(async (event) => {
+  const user = await getUserFromEvent(event);
+  const playlistId = getRouterParam(event, 'id');
+
+  if (!playlistId) {
+    throw createError({ statusCode: 400, statusMessage: 'Playlist ID is required' });
+  }
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+
+  try {
+    const playlist = await db
+      .select({
+        discoveryPlaylistId: discoveryPlaylists.discoveryPlaylistId,
+        title: discoveryPlaylists.title,
+        type: discoveryPlaylists.type,
+        seedArtistId: discoveryPlaylists.seedArtistId,
+      })
+      .from(discoveryPlaylists)
+      .where(
+        and(
+          eq(discoveryPlaylists.discoveryPlaylistId, playlistId),
+          eq(discoveryPlaylists.userId, user.userId)
+        )
+      )
+      .get();
+
+    if (!playlist) {
+      throw createError({ statusCode: 404, statusMessage: 'Discovery playlist not found' });
+    }
+
+    const playlistTrackResults = await db
+      .select({
+        discoveryPlaylistTrackId: discoveryPlaylistTracks.discoveryPlaylistTrackId,
+        order: discoveryPlaylistTracks.order,
+        addedAt: discoveryPlaylistTracks.addedAt,
+        trackId: tracks.trackId,
+        title: tracks.title,
+        duration: tracks.duration,
+        trackNumber: tracks.trackNumber,
+        filePath: tracks.filePath,
+        albumId: albums.albumId,
+        albumTitle: albums.title,
+        coverPath: albums.coverPath,
+        artistId: artists.artistId,
+        artistName: artists.name,
+      })
+      .from(discoveryPlaylistTracks)
+      .innerJoin(tracks, eq(discoveryPlaylistTracks.trackId, tracks.trackId))
+      .leftJoin(albums, eq(tracks.albumId, albums.albumId))
+      .leftJoin(artists, eq(tracks.artistId, artists.artistId))
+      .where(eq(discoveryPlaylistTracks.discoveryPlaylistId, playlistId))
+      .orderBy(asc(discoveryPlaylistTracks.order));
+
+    return {
+      ...playlist,
+      trackCount: playlistTrackResults.length,
+      tracks: playlistTrackResults.map((item) => ({
+        discoveryPlaylistTrackId: item.discoveryPlaylistTrackId,
+        discoveryPlaylistId: playlistId,
+        order: item.order,
+        trackId: item.trackId,
+        addedAt: item.addedAt,
+        track: {
+          trackId: item.trackId,
+          title: item.title,
+          duration: item.duration,
+          trackNumber: item.trackNumber,
+          filePath: item.filePath,
+          albumId: item.albumId,
+          albumTitle: item.albumTitle,
+          coverPath: item.coverPath,
+          artistId: item.artistId,
+          artistName: item.artistName,
+          artists: [],
+          genre: null,
+          year: null,
+          diskNumber: null,
+          explicit: false,
+          createdAt: item.addedAt,
+          updatedAt: item.addedAt,
+        },
+      })),
+    };
+  } catch (error: any) {
+    if (error.statusCode) {
+      throw error;
+    }
+    console.error('Error fetching discovery playlist:', error);
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to fetch discovery playlist',
+    });
+  }
+});

--- a/server/api/discovery-playlists/index.get.ts
+++ b/server/api/discovery-playlists/index.get.ts
@@ -1,0 +1,54 @@
+import { defineEventHandler } from 'h3';
+import { db } from '~/server/db';
+import { discoveryPlaylists, discoveryPlaylistTracks } from '~/server/db/schema';
+import { eq, count } from 'drizzle-orm';
+import { getUserFromEvent } from '~/server/utils/auth';
+
+export default defineEventHandler(async (event) => {
+  const user = await getUserFromEvent(event);
+
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+
+  try {
+    const playlists = await db
+      .select({
+        discoveryPlaylistId: discoveryPlaylists.discoveryPlaylistId,
+        title: discoveryPlaylists.title,
+        type: discoveryPlaylists.type,
+        seedArtistId: discoveryPlaylists.seedArtistId,
+        trackCount: count(discoveryPlaylistTracks.trackId),
+        lastGeneratedAt: discoveryPlaylists.lastGeneratedAt,
+        createdAt: discoveryPlaylists.createdAt,
+        updatedAt: discoveryPlaylists.updatedAt,
+      })
+      .from(discoveryPlaylists)
+      .leftJoin(
+        discoveryPlaylistTracks,
+        eq(
+          discoveryPlaylists.discoveryPlaylistId,
+          discoveryPlaylistTracks.discoveryPlaylistId
+        )
+      )
+      .where(eq(discoveryPlaylists.userId, user.userId))
+      .groupBy(
+        discoveryPlaylists.discoveryPlaylistId,
+        discoveryPlaylists.title,
+        discoveryPlaylists.type,
+        discoveryPlaylists.seedArtistId,
+        discoveryPlaylists.lastGeneratedAt,
+        discoveryPlaylists.createdAt,
+        discoveryPlaylists.updatedAt
+      )
+      .orderBy(discoveryPlaylists.updatedAt);
+
+    return playlists;
+  } catch (error) {
+    console.error('Error fetching discovery playlists:', error);
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to fetch discovery playlists',
+    });
+  }
+});

--- a/types/discovery-playlist.ts
+++ b/types/discovery-playlist.ts
@@ -1,0 +1,20 @@
+export interface DiscoveryPlaylist {
+  discoveryPlaylistId: string;
+  title: string;
+  type: string;
+  seedArtistId?: string | null;
+  lastGeneratedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  trackCount: number;
+  tracks: DiscoveryPlaylistTrack[];
+}
+
+export interface DiscoveryPlaylistTrack {
+  discoveryPlaylistTrackId: string;
+  discoveryPlaylistId: string;
+  trackId: string;
+  order: number;
+  addedAt: string;
+  track: import('./track').Track;
+}


### PR DESCRIPTION
## Summary
- support listing discovery playlists via new API
- support fetching individual discovery playlists
- define `DiscoveryPlaylist` types
- add Discover pages and sidebar navigation

## Testing
- `npx vitest run` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6859b6aa13f883229d6153251a3ed286