### PR TITLE
Add podcast subscriptions

### DIFF
--- a/layouts/sidebar-layout.vue
+++ b/layouts/sidebar-layout.vue
@@ -57,6 +57,7 @@
             <li><NuxtLink to="/artists" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="material-symbols:artist-outline" class="w-5 h-5" /> Artists</NuxtLink></li>
             <li><NuxtLink to="/genres" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="material-symbols:label-outline" class="w-5 h-5" /> Genres</NuxtLink></li>
             <li><NuxtLink to="/playlists" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="material-symbols:mood-outline" class="w-5 h-5" /> Playlists</NuxtLink></li>
+            <li><NuxtLink to="/podcasts" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="material-symbols:podcasts" class="w-5 h-5" /> Podcasts</NuxtLink></li>
             <li><NuxtLink to="/discovery" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="material-symbols:lightbulb-outline" class="w-5 h-5" /> Discover</NuxtLink></li>
             <li><NuxtLink to="/radio" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 mb-1" active-class="!bg-base-300 font-semibold"><Icon name="ph:radio-fill" class="w-5 h-5" /> Radio</NuxtLink></li>
           </ul>

--- a/pages/podcasts/index.vue
+++ b/pages/podcasts/index.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="w-full h-full p-4 overflow-y-auto bg-base-200">
+    <h1 class="text-3xl font-bold mb-6">Podcasts</h1>
+    <div class="flex gap-2 mb-4">
+      <input v-model="feedUrl" type="text" placeholder="Podcast RSS feed" class="input input-bordered flex-grow" />
+      <button class="btn btn-primary" @click="subscribe" :disabled="subscribing">Subscribe</button>
+    </div>
+    <div v-if="pending" class="text-center">
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+    <div v-else-if="error" class="text-center text-error">
+      Failed to load podcasts.
+    </div>
+    <div v-else-if="podcasts && podcasts.length" class="space-y-2">
+      <div v-for="podcast in podcasts" :key="podcast.podcastId" class="p-4 bg-base-100 rounded shadow">
+        <h2 class="font-bold">{{ podcast.title }}</h2>
+        <p class="text-sm text-base-content/70">{{ podcast.description }}</p>
+      </div>
+    </div>
+    <div v-else class="text-center text-base-content/70">No podcasts subscribed yet.</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Podcast } from '~/types/podcast';
+
+definePageMeta({ layout: 'sidebar-layout' });
+
+const { data: podcasts, pending, error, refresh } = await useLazyFetch<Podcast[]>('/api/podcasts');
+
+const feedUrl = ref('');
+const subscribing = ref(false);
+
+const subscribe = async () => {
+  if (!feedUrl.value) return;
+  subscribing.value = true;
+  try {
+    await $fetch('/api/podcasts', { method: 'POST', body: { feedUrl: feedUrl.value } });
+    feedUrl.value = '';
+    await refresh();
+  } catch (err) {
+    console.error('Failed to subscribe', err);
+  } finally {
+    subscribing.value = false;
+  }
+};
+</script>

--- a/server/api/podcasts/[podcastId]/episodes.get.ts
+++ b/server/api/podcasts/[podcastId]/episodes.get.ts
@@ -1,0 +1,41 @@
+import { defineEventHandler, createError } from 'h3';
+import { db } from '~/server/db';
+import { podcasts } from '~/server/db/schema';
+import { eq } from 'drizzle-orm';
+
+function parseEpisodes(xml: string) {
+  const itemRegex = /<item>([\s\S]*?)<\/item>/gi;
+  const items: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = itemRegex.exec(xml))) {
+    items.push(match[1]);
+  }
+  return items.map(block => {
+    const title = block.match(/<title>([^<]+)<\/title>/i)?.[1] ?? '';
+    const pubDate = block.match(/<pubDate>([^<]+)<\/pubDate>/i)?.[1];
+    const audio = block.match(/<enclosure[^>]*url="([^"]+)"[^>]*>/i)?.[1] ?? null;
+    const desc = block.match(/<description>([\s\S]*?)<\/description>/i)?.[1] ?? '';
+    return { title, pubDate, audioUrl: audio, description: desc };
+  });
+}
+
+export default defineEventHandler(async (event) => {
+  const podcastId = event.context.params?.podcastId;
+  if (!podcastId) {
+    throw createError({ statusCode: 400, statusMessage: 'Podcast ID required' });
+  }
+
+  const podcast = await db.select().from(podcasts).where(eq(podcasts.podcastId, podcastId)).get();
+  if (!podcast) {
+    throw createError({ statusCode: 404, statusMessage: 'Podcast not found' });
+  }
+
+  try {
+    const xml = await $fetch<string>(podcast.feedUrl);
+    const episodes = parseEpisodes(xml);
+    return episodes;
+  } catch (error) {
+    console.error('Failed to fetch podcast feed:', error);
+    throw createError({ statusCode: 500, statusMessage: 'Failed to fetch episodes' });
+  }
+});

--- a/server/api/podcasts/index.get.ts
+++ b/server/api/podcasts/index.get.ts
@@ -1,0 +1,30 @@
+import { defineEventHandler, createError } from 'h3';
+import { db } from '~/server/db';
+import { podcasts, podcastSubscriptions } from '~/server/db/schema';
+import { eq } from 'drizzle-orm';
+import { getUserFromEvent } from '~/server/utils/auth';
+
+export default defineEventHandler(async (event) => {
+  const user = await getUserFromEvent(event);
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+
+  const result = await db
+    .select({
+      podcastId: podcasts.podcastId,
+      feedUrl: podcasts.feedUrl,
+      title: podcasts.title,
+      description: podcasts.description,
+      imageUrl: podcasts.imageUrl,
+      createdAt: podcasts.createdAt,
+      updatedAt: podcasts.updatedAt,
+      subscribedAt: podcastSubscriptions.createdAt,
+    })
+    .from(podcastSubscriptions)
+    .leftJoin(podcasts, eq(podcastSubscriptions.podcastId, podcasts.podcastId))
+    .where(eq(podcastSubscriptions.userId, user.userId))
+    .all();
+
+  return result;
+});

--- a/server/api/podcasts/index.post.ts
+++ b/server/api/podcasts/index.post.ts
@@ -1,0 +1,75 @@
+import { defineEventHandler, readBody, createError } from 'h3';
+import { db } from '~/server/db';
+import { podcasts, podcastSubscriptions } from '~/server/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { getUserFromEvent } from '~/server/utils/auth';
+import { v7 as uuidv7 } from 'uuid';
+function parseFeedMeta(xml: string, feedUrl: string) {
+  const title = xml.match(/<title>([^<]+)<\/title>/i)?.[1] ?? feedUrl;
+  const desc = xml.match(/<description>([^<]*)<\/description>/i)?.[1] ?? '';
+  const image = xml.match(/<itunes:image[^>]*href="([^"]+)"[^>]*>/i)?.[1] ?? null;
+  return { title, description: desc, imageUrl: image };
+}
+
+interface SubscribeBody { feedUrl: string }
+
+export default defineEventHandler(async (event) => {
+  const user = await getUserFromEvent(event);
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+
+  const body = await readBody<SubscribeBody>(event);
+  const feedUrl = body.feedUrl?.trim();
+  if (!feedUrl) {
+    throw createError({ statusCode: 400, statusMessage: 'feedUrl required' });
+  }
+
+  let podcast = await db
+    .select()
+    .from(podcasts)
+    .where(eq(podcasts.feedUrl, feedUrl))
+    .get();
+
+  if (!podcast) {
+    try {
+      const xml = await $fetch<string>(feedUrl);
+      const meta = parseFeedMeta(xml, feedUrl);
+      podcast = {
+        podcastId: uuidv7(),
+        feedUrl,
+        title: meta.title,
+        description: meta.description,
+        imageUrl: meta.imageUrl,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      await db.insert(podcasts).values(podcast);
+    } catch (error) {
+      console.error('Failed to parse podcast feed:', error);
+      throw createError({ statusCode: 400, statusMessage: 'Invalid podcast feed' });
+    }
+  }
+
+  const existing = await db
+    .select()
+    .from(podcastSubscriptions)
+    .where(
+      and(
+        eq(podcastSubscriptions.userId, user.userId),
+        eq(podcastSubscriptions.podcastId, podcast.podcastId)
+      )
+    )
+    .get();
+
+  if (!existing) {
+    await db.insert(podcastSubscriptions).values({
+      subscriptionId: uuidv7(),
+      userId: user.userId,
+      podcastId: podcast.podcastId,
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  return podcast;
+});

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -22,6 +22,8 @@ export * from './album-genres';
 export * from './lyrics';
 export * from './discovery-playlists';
 export * from './discovery-playlist-tracks';
+export * from './podcasts';
+export * from './podcast-subscriptions';
 
 // Import table objects specifically for defining relations
 import { users } from './users';
@@ -43,6 +45,8 @@ import { albumGenres } from './album-genres';
 import { lyrics } from './lyrics';
 import { discoveryPlaylists } from './discovery-playlists';
 import { discoveryPlaylistTracks } from './discovery-playlist-tracks';
+import { podcasts } from './podcasts';
+import { podcastSubscriptions } from './podcast-subscriptions';
 
 // === Relations ===
 
@@ -115,6 +119,7 @@ export const userRelations = relations(users, ({ many }) => ({
   mediaFolders: many(mediaFolders),
   radioChannels: many(radioChannels),
   discoveryPlaylists: many(discoveryPlaylists),
+  podcastSubscriptions: many(podcastSubscriptions),
 }));
 
 export const artistUserRelations = relations(artistUsers, ({ one }) => ({
@@ -227,6 +232,21 @@ export const discoveryPlaylistTrackRelations = relations(discoveryPlaylistTracks
   track: one(tracks, {
     fields: [discoveryPlaylistTracks.trackId],
     references: [tracks.trackId],
+  }),
+}));
+
+export const podcastRelations = relations(podcasts, ({ many }) => ({
+  podcastSubscriptions: many(podcastSubscriptions),
+}));
+
+export const podcastSubscriptionRelations = relations(podcastSubscriptions, ({ one }) => ({
+  podcast: one(podcasts, {
+    fields: [podcastSubscriptions.podcastId],
+    references: [podcasts.podcastId],
+  }),
+  user: one(users, {
+    fields: [podcastSubscriptions.userId],
+    references: [users.userId],
   }),
 }));
 

--- a/server/db/schema/podcast-subscriptions.ts
+++ b/server/db/schema/podcast-subscriptions.ts
@@ -1,0 +1,19 @@
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { type InferSelectModel, type InferInsertModel } from 'drizzle-orm';
+import { v7 as uuidv7 } from 'uuid';
+import { users } from './users';
+import { podcasts } from './podcasts';
+
+export const podcastSubscriptions = sqliteTable('podcast_subscriptions', {
+  subscriptionId: text('subscription_id').primaryKey().$defaultFn(() => uuidv7()),
+  userId: text('user_id')
+    .notNull()
+    .references(() => users.userId, { onDelete: 'cascade' }),
+  podcastId: text('podcast_id')
+    .notNull()
+    .references(() => podcasts.podcastId, { onDelete: 'cascade' }),
+  createdAt: text('created_at').$defaultFn(() => new Date().toISOString()).notNull(),
+});
+
+export type PodcastSubscription = InferSelectModel<typeof podcastSubscriptions>;
+export type NewPodcastSubscription = InferInsertModel<typeof podcastSubscriptions>;

--- a/server/db/schema/podcasts.ts
+++ b/server/db/schema/podcasts.ts
@@ -1,0 +1,16 @@
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { type InferSelectModel, type InferInsertModel } from 'drizzle-orm';
+import { v7 as uuidv7 } from 'uuid';
+
+export const podcasts = sqliteTable('podcasts', {
+  podcastId: text('podcast_id').primaryKey().$defaultFn(() => uuidv7()),
+  feedUrl: text('feed_url').notNull().unique(),
+  title: text('title').notNull(),
+  description: text('description'),
+  imageUrl: text('image_url'),
+  createdAt: text('created_at').$defaultFn(() => new Date().toISOString()).notNull(),
+  updatedAt: text('updated_at').$defaultFn(() => new Date().toISOString()).notNull(),
+});
+
+export type Podcast = InferSelectModel<typeof podcasts>;
+export type NewPodcast = InferInsertModel<typeof podcasts>;

--- a/tests/server/api/podcasts/subscribe.test.ts
+++ b/tests/server/api/podcasts/subscribe.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { setup } from '@nuxt/test-utils'
+
+// Verify authentication is required for subscribing
+
+describe('POST /api/podcasts', () => {
+  it('requires authentication', async () => {
+    const nuxt = await setup({ server: true })
+
+    await expect(
+      $fetch('/api/podcasts', {
+        method: 'POST',
+        body: { feedUrl: 'https://example.com/feed' }
+      })
+    ).rejects.toThrow('Unauthorized')
+
+    await nuxt.close()
+  })
+})

--- a/types/podcast.ts
+++ b/types/podcast.ts
@@ -1,0 +1,17 @@
+export interface Podcast {
+  podcastId: string;
+  feedUrl: string;
+  title: string;
+  description?: string;
+  imageUrl?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  subscribedAt?: string;
+}
+
+export interface PodcastEpisode {
+  title: string;
+  pubDate?: string;
+  audioUrl?: string | null;
+  description?: string;
+}


### PR DESCRIPTION
## Summary
- support podcasts table and subscriptions
- create API routes to subscribe and fetch podcasts
- parse podcast feeds and list episodes
- expose new `Podcast` types
- add Podcasts page and navigation link
- test auth requirements for podcast subscriptions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859feff1df8832289f86de45627123e