### PR TITLE
Skip completed albums in scanner

### DIFF
--- a/server/utils/scanner/db-operations.ts
+++ b/server/utils/scanner/db-operations.ts
@@ -1113,7 +1113,12 @@ export async function createInitialAlbumRecord({
     });
 
     if (existingAlbum) {
-      // Album exists, reset its status to PENDING for reprocessing
+      // If the album has already been fully processed, skip it
+      if (existingAlbum.processedStatus === AlbumProcessStatus.COMPLETED) {
+        return null;
+      }
+
+      // Album exists but isn't completed, reset its status for reprocessing
       const [updatedAlbum] = await db
         .update(albums)
         .set({ processedStatus: AlbumProcessStatus.PENDING, updatedAt: new Date().toISOString() })


### PR DESCRIPTION
## Summary
- avoid resetting completed albums to `PENDING`

## Testing
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685a107b5a848322ba77a70369459c98