### PR TITLE
Add placeholder genre art mapping

### DIFF
--- a/composables/useGenreImage.ts
+++ b/composables/useGenreImage.ts
@@ -1,0 +1,19 @@
+import genreImageMap from '~/utils/genre-image-map.json'
+
+/**
+ * Composable to return genre artwork URLs.
+ */
+export const useGenreImage = () => {
+  const defaultImage: string = (genreImageMap as Record<string, string>).default || '/images/icons/default-album-art.webp'
+
+  const getGenreImageUrl = (genreName: string | undefined | null): string => {
+    if (!genreName) {
+      return defaultImage
+    }
+    const key = genreName.toLowerCase()
+    const map = genreImageMap as Record<string, string>
+    return map[key] || defaultImage
+  }
+
+  return { getGenreImageUrl }
+}

--- a/pages/genres/[genreId].vue
+++ b/pages/genres/[genreId].vue
@@ -7,6 +7,7 @@ import { usePlayerStore, type QueueContext } from '~/stores/player';
 import AlbumCard from '~/components/album/album-card.vue'; 
 import { useCoverArt } from '~/composables/use-cover-art';
 import { useTrackArtists } from '~/composables/useTrackArtists';
+import { useGenreImage } from '~/composables/useGenreImage';
 
 interface GenreBasicInfo {
   genreId: string;
@@ -21,6 +22,8 @@ const playerStore = usePlayerStore();
 const genreId = route.params.genreId as string;
 const genreName = ref<string | null>(null);
 const loadingAlbumIdForPlay = ref<string | null>(null);
+
+const { getGenreImageUrl } = useGenreImage();
 
 
 
@@ -164,7 +167,14 @@ definePageMeta({
   <div class="w-full h-full px-4 py-8 overflow-y-auto bg-base-200">
     <div class="mb-6">
       <NuxtLink to="/genres" class="btn btn-ghost btn-sm mb-4">&larr; Back to Genres</NuxtLink>
-      <h1 class="text-3xl font-bold">{{ genreName || 'Genre' }} Albums</h1>
+      <div class="flex items-center gap-4">
+        <img
+          :src="getGenreImageUrl(genreName || '')"
+          :alt="`${genreName} artwork`"
+          class="w-20 h-20 object-cover rounded"
+        />
+        <h1 class="text-3xl font-bold">{{ genreName || 'Genre' }} Albums</h1>
+      </div>
     </div>
 
     <div v-if="pending" class="text-center">

--- a/pages/genres/index.vue
+++ b/pages/genres/index.vue
@@ -1,6 +1,7 @@
 
 <script setup lang="ts">
 import type { Genre } from '~/types/genre';
+import { useGenreImage } from '~/composables/useGenreImage';
 
 // Apply the sidebar layout
 definePageMeta({
@@ -9,6 +10,7 @@ definePageMeta({
 
 // Fetch genres from the API endpoint /api/genres/index.get.ts
 const { data: genres, pending, error } = await useLazyFetch<Genre[]>('/api/genres');
+const { getGenreImageUrl } = useGenreImage();
 
 watch(genres.value, (newGenres: Genre[] | null) => {
   if (newGenres) {
@@ -66,12 +68,19 @@ const filteredGenres = computed(() => {
       <p>No genres found.</p>
     </div>
     <div v-else class="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-      <NuxtLink 
-        v-for="genre in filteredGenres" 
-        :key="genre.genreId" 
+      <NuxtLink
+        v-for="genre in filteredGenres"
+        :key="genre.genreId"
         :to="`/genres/${genre.genreId}`"
         class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow duration-300"
       >
+        <figure class="aspect-square overflow-hidden">
+          <img
+            :src="getGenreImageUrl(genre.name)"
+            :alt="`${genre.name} artwork`"
+            class="w-full h-full object-cover"
+          />
+        </figure>
         <div class="card-body">
           <h2 class="card-title truncate">{{ genre.name }}</h2>
           <p class="text-sm text-base-content/70">{{ genre.albumCount }} album{{ genre.albumCount !== 1 ? 's' : '' }}</p>

--- a/utils/genre-image-map.json
+++ b/utils/genre-image-map.json
@@ -1,0 +1,6 @@
+{
+  "default": "/images/icons/default-album-art.webp",
+  "rock": "/images/genres/rock-art.webp",
+  "jazz": "/images/genres/jazz-art.webp",
+  "pop": "/images/genres/pop-art.webp"
+}


### PR DESCRIPTION
## Summary
- map genres to images using a JSON map with example entries
- use existing default album art instead of introducing a new placeholder
- show genre images via `useGenreImage` composable

## Testing
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_685a294448fc832298e66ba9fb8ffdfc