### PR TITLE
feat(scanner): detect singles and improve artist logic

### DIFF
--- a/tests/server/scanner/is-single-folder.test.ts
+++ b/tests/server/scanner/is-single-folder.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { isSingleFolder } from '~/server/utils/scanner'
+
+describe('isSingleFolder', () => {
+  it('returns true when only one audio file exists', () => {
+    expect(isSingleFolder(['one.mp3'])).toBe(true)
+  })
+
+  it('returns false when multiple audio files exist', () => {
+    expect(isSingleFolder(['one.mp3', 'two.mp3'])).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add `isSingleFolder` helper
- use single detection when processing album folders
- avoid marking single folders as various artist compilations
- export scanning helpers and add a small test

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2a920be0832288c404acaafba315