### PR TITLE
Add toast on new radio station

### DIFF
--- a/components/modals/edit-radio-station-modal.vue
+++ b/components/modals/edit-radio-station-modal.vue
@@ -118,7 +118,7 @@ async function submitForm() {
     const url = isEditing.value ? `/api/radio-stations/${props.station!.channelId}` : '/api/radio-stations';
     const method = isEditing.value ? 'PUT' : 'POST';
 
-    await $fetch(url, {
+    const newStation = await $fetch(url, {
       method,
       body: {
         name: formData.value.name,
@@ -127,7 +127,7 @@ async function submitForm() {
       },
     });
 
-    emit('station-updated');
+    emit('station-updated', newStation);
     closeModal();
   } catch (error) {
     console.error('Failed to save radio station:', error);

--- a/pages/settings/radio/index.vue
+++ b/pages/settings/radio/index.vue
@@ -61,11 +61,11 @@
     </div>
 
     <!-- Add/Edit Modal -->
-    <EditRadioStationModal 
+    <EditRadioStationModal
       :open="isEditModalOpen"
       :station="selectedStation"
       @close="closeEditModal"
-      @station-updated="refreshStations"
+      @station-updated="handleStationUpdated"
     />
     
     <!-- Delete Confirmation Modal -->
@@ -85,6 +85,7 @@ import type { Artist } from '~/server/db/schema/artists';
 import type { Genre } from '~/server/db/schema/genres';
 import EditRadioStationModal from '~/components/modals/edit-radio-station-modal.vue';
 import ConfirmDeleteModal from '~/components/modals/confirm-delete-modal.vue';
+import { useToast } from '~/composables/useToast';
 
 // Define the detailed type for a station, matching the API response
 interface Station extends RadioChannel {
@@ -100,6 +101,7 @@ const stations = ref<Station[]>([]);
 const isEditModalOpen = ref(false);
 const isDeleteModalOpen = ref(false);
 const selectedStation = ref<Station | null>(null);
+const toast = useToast();
 
 async function fetchStations() {
   try {
@@ -133,6 +135,14 @@ function openDeleteModal(station: Station) {
 function closeDeleteModal() {
   isDeleteModalOpen.value = false;
   selectedStation.value = null;
+}
+
+async function handleStationUpdated(updatedStation: Station) {
+  await refreshStations();
+  const message = selectedStation.value
+    ? `Updated station "${updatedStation.name}"`
+    : `Created station "${updatedStation.name}"`;
+  toast.add({ message, type: 'success' });
 }
 
 async function deleteStation() {


### PR DESCRIPTION
## Summary
- emit created station data from modal
- refresh station list and show toast after creation

## Testing
- `pnpm test` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685c05b1f4908322a6e9f19bdd8390e9