### PR TITLE
Fix recursive audio scanning

### DIFF
--- a/server/utils/scanner/index.ts
+++ b/server/utils/scanner/index.ts
@@ -1,6 +1,5 @@
-import * as fs from 'fs/promises';
 import * as mm from 'music-metadata';
-import { basename, dirname, extname, join } from 'path';
+import { basename, dirname } from 'path';
 import { db } from '~/server/db';
 import { type Album, type Artist, albums, tracks, artistUsers } from '~/server/db/schema';
 import { eq, and, sql } from 'drizzle-orm';
@@ -212,11 +211,7 @@ export async function scanLibrary({
   const stats: ScanStats = { scannedFiles: 0, addedTracks: 0, addedArtists: 0, addedAlbums: 0, completedAlbums: 0, failedAlbums: 0, errors: 0 };
 
   try {
-    const allFiles = await fs.readdir(libraryPath, { recursive: true });
-    const audioFiles = allFiles.map(file => join(libraryPath, file.toString())).filter(file => {
-      const ext = extname(file).toLowerCase();
-      return ['.mp3', '.flac', '.m4a', '.aac', '.ogg', '.wav'].includes(ext);
-    });
+    const audioFiles = await fileUtils.findAudioFiles(libraryPath);
     stats.scannedFiles = audioFiles.length;
     console.log(`Found ${stats.scannedFiles} audio files.`);
 

--- a/tests/server/scanner/find-audio-files.test.ts
+++ b/tests/server/scanner/find-audio-files.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { findAudioFiles } from '~/server/utils/scanner'
+import { tmpdir } from 'os'
+import { mkdtemp, writeFile, mkdir, rm } from 'fs/promises'
+import { join } from 'path'
+
+function createFile(path: string) {
+  return writeFile(path, '')
+}
+
+describe('findAudioFiles', () => {
+  it('recursively returns supported audio files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'audio-'))
+    try {
+      // create nested structure
+      await createFile(join(root, 'a.mp3'))
+      await createFile(join(root, 'ignore.txt'))
+
+      const sub = join(root, 'sub')
+      await mkdir(sub)
+      await createFile(join(sub, 'b.flac'))
+
+      const deep = join(sub, 'deep')
+      await mkdir(deep)
+      await createFile(join(deep, 'c.ogg'))
+
+      const files = await findAudioFiles(root)
+      const relative = files.map(f => f.replace(root + '/', '')).sort()
+      expect(relative).toEqual(['a.mp3', 'sub/b.flac', 'sub/deep/c.ogg'])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- search audio files recursively with `findAudioFiles`
- test `findAudioFiles` to ensure recursion

## Testing
- `pnpm exec vitest` *(fails: Error when performing the request to https://registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685c9e8e1764832294a5a3407f67ff38