### PR TITLE
Regenerate scan job migration with drizzle-kit

### DIFF
--- a/docs/refactor/BASELINE.md
+++ b/docs/refactor/BASELINE.md
@@ -1,0 +1,22 @@
+# Baseline: Directory Scanning + Ingestion Flow
+
+## Entrypoints
+- `server/api/libraries/[libraryId]/scan.post.ts` (fire-and-forget call to scanner from request handler).
+- `server/api/settings/scan/index.post.ts` (multi-folder scan directly awaited in request handler).
+- `server/utils/scanner/index.ts` (`scanLibrary` does traversal, metadata extraction, remote enrichment, and DB writes in one path).
+- `server/utils/scanner/file-utils.ts` (`findAudioFiles` recursively reads directories and returns full array).
+- `server/utils/scanner/progress-tracker.ts` (in-memory session tracking only).
+
+## Current call graph (short)
+1. HTTP scan route validates auth + folder.
+2. Route calls `scanLibrary(...)`.
+3. Scanner reads all file paths (`findAudioFiles`) into memory.
+4. Scanner parses metadata/enrichment per file and performs DB writes via `db-operations`.
+5. Route either blocks until completion (`settings/scan`) or returns while same process continues (`libraries/:id/scan`).
+
+## Top 5 root-cause risks
+1. **Heavy work on request thread**: scan work is initiated from API handlers and in one route directly awaited.
+2. **Unbounded memory growth**: traversal accumulates full audio path list before processing.
+3. **No durable queue/progress**: progress state is in-memory and lost on restart; no persisted cancellation state.
+4. **Duplicate/fragmented scan orchestration**: multiple routes trigger scans with inconsistent behavior and retry/backpressure semantics.
+5. **Resource spikes**: metadata extraction + DB writes happen in large loops without strict global job concurrency/backpressure controls.

--- a/docs/refactor/DATA_INTEGRITY.md
+++ b/docs/refactor/DATA_INTEGRITY.md
@@ -1,0 +1,21 @@
+# Data Integrity: Queue + Scan Pipeline
+
+## Constraints
+- `scan_files(scan_id, path)` is unique to guarantee idempotent retries and prevent duplicate rows.
+- `scan_runs.job_id` references `job_queue.job_id` with cascade delete to keep queue/scan linkage consistent.
+
+## Upsert semantics
+- File rows are inserted in batches and updated on conflict (`size_bytes`, `mtime_ms`, `extension`, `updated_at`).
+- This keeps rescans deterministic and safe under retries.
+
+## Retry policy
+- Queue retries transient failures with exponential backoff (`2^attempts`, capped at 60s).
+- After `maxAttempts`, job becomes `failed` and `scan_runs.last_error` is recorded.
+
+## Indexes
+- Queue scheduling indexes:
+  - `job_queue_state_run_after_idx`
+  - `job_queue_type_state_run_after_idx`
+- UI/status indexes:
+  - `scan_runs_user_state_idx`
+  - `scan_files_scan_id_idx`

--- a/server/api/libraries/[libraryId]/scan.post.ts
+++ b/server/api/libraries/[libraryId]/scan.post.ts
@@ -1,92 +1,23 @@
-import { z } from 'zod'
-import { db } from '~/server/db'
-import { mediaFolders } from '~/server/db/schema'
-import { eq, and } from 'drizzle-orm'
-import { scanLibrary } from '~/server/utils/scanner'
-import type { H3Event } from 'h3'
+import { z } from 'zod';
+import { enqueueScanForLibrary } from '~/server/services/scanner/enqueue';
+import type { H3Event } from 'h3';
 
-// Schema to validate the route parameter
 const paramsSchema = z.object({
-  libraryId: z.coerce.number().int().positive('Library ID must be a positive integer')
-})
+  libraryId: z.string().min(1),
+});
 
 export default defineEventHandler(async (event: H3Event) => {
-  // 1. Ensure user is authenticated
-  const user = event.context.user
-  if (!user || !user.userId) {
-    throw createError({
-      statusCode: 401,
-      statusMessage: 'Unauthorized: Authentication required.'
-    })
+  const user = event.context.user;
+  if (!user?.userId) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized: Authentication required.' });
   }
 
-  // 2. Validate libraryId from route parameters
-  const params = await getValidatedRouterParams(event, params => paramsSchema.safeParse(params))
-
+  const params = await getValidatedRouterParams(event, (raw) => paramsSchema.safeParse(raw));
   if (!params.success) {
-     throw createError({
-      statusCode: 400,
-      statusMessage: 'Bad Request: Invalid Library ID provided in URL.',
-      data: params.error.format()
-    })
+    throw createError({ statusCode: 400, statusMessage: 'Bad Request: Invalid Library ID provided in URL.', data: params.error.format() });
   }
 
-  const libraryId = params.data.libraryId
-
-  try {
-    // 3. Verify the library belongs to the user and get its path
-    const [library] = await db
-      .select({ mediaFolderId: mediaFolders.mediaFolderId, path: mediaFolders.path })
-      .from(mediaFolders)
-      .where(and(
-        eq(mediaFolders.mediaFolderId, String(libraryId)),
-        eq(mediaFolders.userId, user.userId)
-      ))
-      .limit(1)
-
-    if (!library) {
-      throw createError({
-        statusCode: 404,
-        statusMessage: 'Not Found: Library not found or access denied.'
-      })
-    }
-
-    // 4. Trigger scan asynchronously (fire-and-forget)
-    // We don't await this, so the request returns immediately.
-    // Error handling within scanLibrary should log issues.
-    scanLibrary({
-      libraryId: String(libraryId),
-      libraryPath: library.path,
-      userId: user.userId,
-      processOnlyUnprocessed: true,
-    })
-    .then((stats) => {
-      console.log(`Enhanced scan completed for library ${libraryId}:`, stats);
-      console.log(`- Files processed: ${stats.addedTracks}/${stats.scannedFiles}`);
-      console.log(`- Albums added: ${stats.addedAlbums}`);
-      console.log(`- Artists added: ${stats.addedArtists}`);
-      console.log(`- Skipped files: ${stats.skippedFiles}`);
-      console.log(`- Errors: ${stats.errors}`);
-    })
-    .catch((error) => {
-      console.error(`Enhanced scan failed for library ${libraryId}:`, error);
-    });
-
-    console.log(`Scan initiated for library ${library.mediaFolderId} by user ${user.userId}`);
-    
-    // 5. Return success response
-    setResponseStatus(event, 202) // 202 Accepted indicates the request is accepted for processing
-    return { message: `Scan initiated for library ${library.mediaFolderId}.` }
-
-  } catch (error: any) {
-     // Handle errors from DB query or other synchronous parts
-     if (error.statusCode) { // Re-throw H3 errors
-       throw error;
-     }
-     console.error(`Error initiating scan for library ${libraryId}:`, error)
-     throw createError({
-       statusCode: 500,
-       statusMessage: 'Internal Server Error: Could not initiate library scan.'
-     })
-   }
-})
+  const { scanId, jobId } = await enqueueScanForLibrary({ libraryId: params.data.libraryId, options: {} }, user.userId);
+  setResponseStatus(event, 202);
+  return { message: 'Scan queued.', scanId, jobId };
+});

--- a/server/api/libraries/[libraryId]/scan.post.ts
+++ b/server/api/libraries/[libraryId]/scan.post.ts
@@ -17,7 +17,11 @@ export default defineEventHandler(async (event: H3Event) => {
     throw createError({ statusCode: 400, statusMessage: 'Bad Request: Invalid Library ID provided in URL.', data: params.error.format() });
   }
 
-  const { scanId, jobId } = await enqueueScanForLibrary({ libraryId: params.data.libraryId, options: {} }, user.userId);
+  const { scanId, jobId } = await enqueueScanForLibrary({
+    libraryId: params.data.libraryId,
+    processOnlyUnprocessed: true,
+    options: {},
+  }, user.userId);
   setResponseStatus(event, 202);
   return { message: 'Scan queued.', scanId, jobId };
 });

--- a/server/api/scan/cancel.post.ts
+++ b/server/api/scan/cancel.post.ts
@@ -4,6 +4,7 @@ import { getUserFromEvent } from '~/server/utils/auth';
 import { db } from '~/server/db';
 import { scanRuns } from '~/server/db/schema';
 import { requestJobCancel } from '~/server/jobs/queue';
+import { buildCancelResponse } from '~/server/services/scanner/cancel-response';
 
 const cancelSchema = z.object({ scanId: z.string().min(1) });
 
@@ -27,6 +28,6 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: 'Scan not found' });
   }
 
-  await requestJobCancel(scan.jobId);
-  return { scanId: body.data.scanId, cancelled: true };
+  const cancelRequest = await requestJobCancel(scan.jobId);
+  return buildCancelResponse(body.data.scanId, cancelRequest);
 });

--- a/server/api/scan/cancel.post.ts
+++ b/server/api/scan/cancel.post.ts
@@ -1,0 +1,32 @@
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { getUserFromEvent } from '~/server/utils/auth';
+import { db } from '~/server/db';
+import { scanRuns } from '~/server/db/schema';
+import { requestJobCancel } from '~/server/jobs/queue';
+
+const cancelSchema = z.object({ scanId: z.string().min(1) });
+
+export default defineEventHandler(async (event) => {
+  const user = await getUserFromEvent(event);
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+
+  const body = await readValidatedBody(event, (raw) => cancelSchema.safeParse(raw));
+  if (!body.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid cancel payload', data: body.error.flatten() });
+  }
+
+  const [scan] = await db.select({ jobId: scanRuns.jobId })
+    .from(scanRuns)
+    .where(and(eq(scanRuns.scanId, body.data.scanId), eq(scanRuns.userId, user.userId)))
+    .limit(1);
+
+  if (!scan) {
+    throw createError({ statusCode: 404, statusMessage: 'Scan not found' });
+  }
+
+  await requestJobCancel(scan.jobId);
+  return { scanId: body.data.scanId, cancelled: true };
+});

--- a/server/api/scan/start.post.ts
+++ b/server/api/scan/start.post.ts
@@ -1,0 +1,19 @@
+import { getUserFromEvent } from '~/server/utils/auth';
+import { startScanSchema } from '~/server/services/scanner/schemas';
+import { enqueueScanForLibrary } from '~/server/services/scanner/enqueue';
+
+export default defineEventHandler(async (event) => {
+  const user = await getUserFromEvent(event);
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+
+  const body = await readValidatedBody(event, (raw) => startScanSchema.safeParse(raw));
+  if (!body.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid scan payload', data: body.error.flatten() });
+  }
+
+  const { scanId, jobId } = await enqueueScanForLibrary(body.data, user.userId);
+  setResponseStatus(event, 202);
+  return { scanId, jobId };
+});

--- a/server/api/scan/status.get.ts
+++ b/server/api/scan/status.get.ts
@@ -1,0 +1,47 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '~/server/db';
+import { jobQueue, scanRuns } from '~/server/db/schema';
+import { getUserFromEvent } from '~/server/utils/auth';
+
+export default defineEventHandler(async (event) => {
+  const user = await getUserFromEvent(event);
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+
+  const scanId = getQuery(event).scanId as string | undefined;
+  if (!scanId) {
+    throw createError({ statusCode: 400, statusMessage: 'scanId is required' });
+  }
+
+  const rows = await db.select({
+    scanId: scanRuns.scanId,
+    state: scanRuns.state,
+    filesDiscovered: scanRuns.filesDiscovered,
+    filesPersisted: scanRuns.filesPersisted,
+    batchesFlushed: scanRuns.batchesFlushed,
+    errors: scanRuns.errors,
+    lastError: scanRuns.lastError,
+    progress: jobQueue.progress,
+  }).from(scanRuns)
+    .innerJoin(jobQueue, eq(scanRuns.jobId, jobQueue.jobId))
+    .where(and(eq(scanRuns.scanId, scanId), eq(scanRuns.userId, user.userId)))
+    .limit(1);
+
+  const status = rows[0];
+  if (!status) {
+    throw createError({ statusCode: 404, statusMessage: 'Scan not found' });
+  }
+
+  return {
+    state: status.state,
+    progress: status.progress ? JSON.parse(status.progress) : null,
+    counts: {
+      filesDiscovered: status.filesDiscovered,
+      filesPersisted: status.filesPersisted,
+      batchesFlushed: status.batchesFlushed,
+      errors: status.errors,
+    },
+    errors: status.lastError ? [status.lastError] : [],
+  };
+});

--- a/server/api/settings/scan/index.post.ts
+++ b/server/api/settings/scan/index.post.ts
@@ -1,101 +1,30 @@
-// server/api/settings/scan/index.post.ts
 import { defineEventHandler, createError } from 'h3';
 import { db } from '~/server/db';
 import { mediaFolders } from '~/server/db/schema';
-import { scanLibrary } from '~/server/utils/scanner';
 import { batchMap } from '~/utils/concurrency';
-import { desc, eq, and } from 'drizzle-orm'; 
-import { getUserFromEvent } from '~/server/utils/auth'; 
+import { desc, eq } from 'drizzle-orm';
+import { getUserFromEvent } from '~/server/utils/auth';
+import { enqueueScanForLibrary } from '~/server/services/scanner/enqueue';
 
 export default defineEventHandler(async (event) => {
-  console.log('Received request to start media scan...');
-
-  const user = await getUserFromEvent(event); 
-  if (!user) { 
-    throw createError({
-      statusCode: 401,
-      statusMessage: 'Unauthorized',
-    });
+  const user = await getUserFromEvent(event);
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
   }
 
-  try {
-    // Fetch folders for the authenticated user
-    const foldersToScan = await db.select({ 
-        mediaFolderId: mediaFolders.mediaFolderId, 
-        path: mediaFolders.path 
-      })
-      .from(mediaFolders)
-      .where(eq(mediaFolders.userId, user.userId)) 
-      .orderBy(desc(mediaFolders.createdAt))
-      .all();
+  const folders = await db.select({ mediaFolderId: mediaFolders.mediaFolderId })
+    .from(mediaFolders)
+    .where(eq(mediaFolders.userId, user.userId))
+    .orderBy(desc(mediaFolders.createdAt));
 
-    if (!foldersToScan || foldersToScan.length === 0) {
-      console.log('No media folders configured for scan for this user.');
-      return { success: true, message: 'No media folders configured for scanning for this user.', scanned: 0, added: 0, errors: 0 };
-    }
+  const queued = await batchMap(folders, 3, async (folder) => {
+    return enqueueScanForLibrary({ libraryId: folder.mediaFolderId, options: {} }, user.userId);
+  });
 
-    console.log(`Starting scan for ${foldersToScan.length} media folder(s) for user ${user.userId}...`);
-    
-    // Initialize counters
-    let totalScanned = 0;
-    let totalAddedTracks = 0;
-    let totalAddedArtists = 0;
-    let totalAddedAlbums = 0;
-    let totalErrors = 0;
-
-    // Scan folders concurrently in small batches to reduce overall time
-    const scanResults = await batchMap(foldersToScan, 2, async (folder) => {
-      if (!folder.mediaFolderId) {
-        console.warn(`Folder with path ${folder.path} is missing an ID. Skipping.`);
-        return { stats: null, error: true };
-      }
-
-      console.log(`Scanning folder: ${folder.path} (ID: ${folder.mediaFolderId}) for user ${user.userId}`);
-
-      try {
-        const scanStats = await scanLibrary({
-          libraryId: folder.mediaFolderId,
-          libraryPath: folder.path,
-          userId: user.userId,
-        });
-
-        console.log(`Successfully scanned folder: ${folder.path}`);
-        return { stats: scanStats, error: false };
-      } catch (error: any) {
-        console.error(`Error scanning folder ${folder.path}: ${error.message}`);
-        return { stats: null, error: true };
-      }
-    });
-
-    for (const result of scanResults) {
-      if (result.error) {
-        totalErrors++;
-        continue;
-      }
-      if (result.stats) {
-        totalScanned++;
-        totalAddedTracks += result.stats.addedTracks;
-        totalAddedArtists += result.stats.addedArtists;
-        totalAddedAlbums += result.stats.addedAlbums;
-        totalErrors += result.stats.errors;
-      }
-    }
-
-    console.log(`Scan completed for user ${user.userId}. Processed ${totalScanned} folders with ${totalErrors} errors.`);
-    return {
-      success: true,
-      message: `Scan completed for ${totalScanned} folders.`,
-      scanned: totalScanned,
-      addedTracks: totalAddedTracks,
-      addedArtists: totalAddedArtists,
-      addedAlbums: totalAddedAlbums,
-      errors: totalErrors
-    };
-  } catch (error: any) {
-    console.error(`Error during scan operation for user ${user.userId}: ${error.message}`);
-    throw createError({
-      statusCode: 500,
-      statusMessage: `Internal server error: ${error.message}`
-    });
-  }
+  setResponseStatus(event, 202);
+  return {
+    success: true,
+    message: `Queued ${queued.length} scan job(s).`,
+    scans: queued.map((q) => ({ scanId: q.scanId, jobId: q.jobId })),
+  };
 });

--- a/server/api/settings/scan/index.post.ts
+++ b/server/api/settings/scan/index.post.ts
@@ -18,7 +18,11 @@ export default defineEventHandler(async (event) => {
     .orderBy(desc(mediaFolders.createdAt));
 
   const queued = await batchMap(folders, 3, async (folder) => {
-    return enqueueScanForLibrary({ libraryId: folder.mediaFolderId, options: {} }, user.userId);
+    return enqueueScanForLibrary({
+      libraryId: folder.mediaFolderId,
+      processOnlyUnprocessed: false,
+      options: {},
+    }, user.userId);
   });
 
   setResponseStatus(event, 202);

--- a/server/db/migrations/0002_colossal_christian_walker.sql
+++ b/server/db/migrations/0002_colossal_christian_walker.sql
@@ -1,0 +1,55 @@
+CREATE TABLE `job_queue` (
+	`job_id` text PRIMARY KEY NOT NULL,
+	`job_type` text NOT NULL,
+	`payload` text NOT NULL,
+	`state` text DEFAULT 'queued' NOT NULL,
+	`attempts` integer DEFAULT 0 NOT NULL,
+	`max_attempts` integer DEFAULT 3 NOT NULL,
+	`run_after` integer DEFAULT (unixepoch()) NOT NULL,
+	`leased_until` integer,
+	`lease_owner` text,
+	`cancel_requested` integer DEFAULT false NOT NULL,
+	`progress` text,
+	`result` text,
+	`last_error` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `job_queue_type_state_run_after_idx` ON `job_queue` (`job_type`,`state`,`run_after`);--> statement-breakpoint
+CREATE INDEX `job_queue_state_run_after_idx` ON `job_queue` (`state`,`run_after`);--> statement-breakpoint
+CREATE INDEX `job_queue_lease_owner_idx` ON `job_queue` (`lease_owner`);--> statement-breakpoint
+CREATE TABLE `scan_files` (
+	`scan_file_id` text PRIMARY KEY NOT NULL,
+	`scan_id` text NOT NULL,
+	`path` text NOT NULL,
+	`size_bytes` integer,
+	`mtime_ms` integer,
+	`extension` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`scan_id`) REFERENCES `scan_runs`(`scan_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `scan_files_scan_id_path_unique` ON `scan_files` (`scan_id`,`path`);--> statement-breakpoint
+CREATE INDEX `scan_files_scan_id_idx` ON `scan_files` (`scan_id`);--> statement-breakpoint
+CREATE TABLE `scan_runs` (
+	`scan_id` text PRIMARY KEY NOT NULL,
+	`job_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`root_path` text NOT NULL,
+	`state` text DEFAULT 'queued' NOT NULL,
+	`files_discovered` integer DEFAULT 0 NOT NULL,
+	`files_persisted` integer DEFAULT 0 NOT NULL,
+	`batches_flushed` integer DEFAULT 0 NOT NULL,
+	`errors` integer DEFAULT 0 NOT NULL,
+	`last_error` text,
+	`started_at` text,
+	`finished_at` text,
+	`cancelled_at` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`job_id`) REFERENCES `job_queue`(`job_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `scan_runs_user_state_idx` ON `scan_runs` (`user_id`,`state`);

--- a/server/db/migrations/meta/0002_snapshot.json
+++ b/server/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,2093 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b176b99a-f386-4cac-bb6b-155acdb6bacb",
+  "prevId": "452d26f4-bf1f-467e-9a2d-e888e493bac9",
+  "tables": {
+    "users": {
+      "name": "users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_track_plays": {
+      "name": "user_track_plays",
+      "columns": {
+        "user_track_play_id": {
+          "name": "user_track_play_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "play_duration_ms": {
+          "name": "play_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_track_plays_user_id_users_user_id_fk": {
+          "name": "user_track_plays_user_id_users_user_id_fk",
+          "tableFrom": "user_track_plays",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_track_plays_track_id_tracks_track_id_fk": {
+          "name": "user_track_plays_track_id_tracks_track_id_fk",
+          "tableFrom": "user_track_plays",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "track_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_image": {
+          "name": "artist_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artist_users": {
+      "name": "artist_users",
+      "columns": {
+        "artist_user_id": {
+          "name": "artist_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_users_artist_id_artists_artist_id_fk": {
+          "name": "artist_users_artist_id_artists_artist_id_fk",
+          "tableFrom": "artist_users",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "artist_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_users_user_id_users_user_id_fk": {
+          "name": "artist_users_user_id_users_user_id_fk",
+          "tableFrom": "artist_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_path": {
+          "name": "cover_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processed_status": {
+          "name": "processed_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -1
+        },
+        "folder_path": {
+          "name": "folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "musicbrainz_release_id": {
+          "name": "musicbrainz_release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "albums_user_id_users_user_id_fk": {
+          "name": "albums_user_id_users_user_id_fk",
+          "tableFrom": "albums",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "album_artists": {
+      "name": "album_artists",
+      "columns": {
+        "album_artist_id": {
+          "name": "album_artist_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary_artist": {
+          "name": "is_primary_artist",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'performer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_artists_album_id_albums_album_id_fk": {
+          "name": "album_artists_album_id_albums_album_id_fk",
+          "tableFrom": "album_artists",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "album_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "album_artists_artist_id_artists_artist_id_fk": {
+          "name": "album_artists_artist_id_artists_artist_id_fk",
+          "tableFrom": "album_artists",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "artist_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "radio_channels": {
+      "name": "radio_channels",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dynamic": {
+          "name": "dynamic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "logo_image_path": {
+          "name": "logo_image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_image_path": {
+          "name": "background_image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "radio_channels_user_id_users_user_id_fk": {
+          "name": "radio_channels_user_id_users_user_id_fk",
+          "tableFrom": "radio_channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "radio_channel_tracks": {
+      "name": "radio_channel_tracks",
+      "columns": {
+        "radio_track_id": {
+          "name": "radio_track_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "radio_channel_tracks_channel_id_radio_channels_channel_id_fk": {
+          "name": "radio_channel_tracks_channel_id_radio_channels_channel_id_fk",
+          "tableFrom": "radio_channel_tracks",
+          "tableTo": "radio_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "channel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "radio_channel_tracks_track_id_tracks_track_id_fk": {
+          "name": "radio_channel_tracks_track_id_tracks_track_id_fk",
+          "tableFrom": "radio_channel_tracks",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "track_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "radio_channel_artists": {
+      "name": "radio_channel_artists",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "radio_channel_artists_channel_id_radio_channels_channel_id_fk": {
+          "name": "radio_channel_artists_channel_id_radio_channels_channel_id_fk",
+          "tableFrom": "radio_channel_artists",
+          "tableTo": "radio_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "channel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "radio_channel_artists_artist_id_artists_artist_id_fk": {
+          "name": "radio_channel_artists_artist_id_artists_artist_id_fk",
+          "tableFrom": "radio_channel_artists",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "artist_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "radio_channel_artists_channel_id_artist_id_pk": {
+          "columns": [
+            "channel_id",
+            "artist_id"
+          ],
+          "name": "radio_channel_artists_channel_id_artist_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "radio_channel_genres": {
+      "name": "radio_channel_genres",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "radio_channel_genres_channel_id_radio_channels_channel_id_fk": {
+          "name": "radio_channel_genres_channel_id_radio_channels_channel_id_fk",
+          "tableFrom": "radio_channel_genres",
+          "tableTo": "radio_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "channel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "radio_channel_genres_genre_id_genres_genre_id_fk": {
+          "name": "radio_channel_genres_genre_id_genres_genre_id_fk",
+          "tableFrom": "radio_channel_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "genre_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "radio_channel_genres_channel_id_genre_id_pk": {
+          "columns": [
+            "channel_id",
+            "genre_id"
+          ],
+          "name": "radio_channel_genres_channel_id_genre_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track_number": {
+          "name": "track_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disk_number": {
+          "name": "disk_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "explicit": {
+          "name": "explicit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "musicbrainz_track_id": {
+          "name": "musicbrainz_track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tracks_file_path_unique": {
+          "name": "tracks_file_path_unique",
+          "columns": [
+            "file_path"
+          ],
+          "isUnique": true
+        },
+        "tracks_musicbrainz_track_id_unique": {
+          "name": "tracks_musicbrainz_track_id_unique",
+          "columns": [
+            "musicbrainz_track_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tracks_album_id_albums_album_id_fk": {
+          "name": "tracks_album_id_albums_album_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "album_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists_tracks": {
+      "name": "artists_tracks",
+      "columns": {
+        "artists_tracks_id": {
+          "name": "artists_tracks_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary_artist": {
+          "name": "is_primary_artist",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artists_tracks_artist_id_artists_artist_id_fk": {
+          "name": "artists_tracks_artist_id_artists_artist_id_fk",
+          "tableFrom": "artists_tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "artist_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artists_tracks_track_id_tracks_track_id_fk": {
+          "name": "artists_tracks_track_id_tracks_track_id_fk",
+          "tableFrom": "artists_tracks",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "track_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "playlists_user_id_users_user_id_fk": {
+          "name": "playlists_user_id_users_user_id_fk",
+          "tableFrom": "playlists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlist_tracks": {
+      "name": "playlist_tracks",
+      "columns": {
+        "playlist_tracks_id": {
+          "name": "playlist_tracks_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "playlist_tracks_playlist_id_playlists_playlist_id_fk": {
+          "name": "playlist_tracks_playlist_id_playlists_playlist_id_fk",
+          "tableFrom": "playlist_tracks",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "playlist_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_tracks_track_id_tracks_track_id_fk": {
+          "name": "playlist_tracks_track_id_tracks_track_id_fk",
+          "tableFrom": "playlist_tracks",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "track_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_folders": {
+      "name": "media_folders",
+      "columns": {
+        "media_folders_id": {
+          "name": "media_folders_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_folders_user_id_users_user_id_fk": {
+          "name": "media_folders_user_id_users_user_id_fk",
+          "tableFrom": "media_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genres": {
+      "name": "genres",
+      "columns": {
+        "genre_id": {
+          "name": "genre_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "album_genres": {
+      "name": "album_genres",
+      "columns": {
+        "album_genre_id": {
+          "name": "album_genre_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_genres_album_id_albums_album_id_fk": {
+          "name": "album_genres_album_id_albums_album_id_fk",
+          "tableFrom": "album_genres",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "album_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "album_genres_genre_id_genres_genre_id_fk": {
+          "name": "album_genres_genre_id_genres_genre_id_fk",
+          "tableFrom": "album_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "genre_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lyrics": {
+      "name": "lyrics",
+      "columns": {
+        "lyrics_id": {
+          "name": "lyrics_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lyrics_json": {
+          "name": "lyrics_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "llm_model_used": {
+          "name": "llm_model_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_llm_output": {
+          "name": "raw_llm_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "lyrics_track_idx": {
+          "name": "lyrics_track_idx",
+          "columns": [
+            "track_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lyrics_track_id_tracks_track_id_fk": {
+          "name": "lyrics_track_id_tracks_track_id_fk",
+          "tableFrom": "lyrics",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "track_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discovery_playlists": {
+      "name": "discovery_playlists",
+      "columns": {
+        "discovery_playlist_id": {
+          "name": "discovery_playlist_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed_artist_id": {
+          "name": "seed_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_params": {
+          "name": "generation_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dp_user_type_title_idx": {
+          "name": "dp_user_type_title_idx",
+          "columns": [
+            "user_id",
+            "type",
+            "title"
+          ],
+          "isUnique": true
+        },
+        "dp_user_type_seed_artist_idx": {
+          "name": "dp_user_type_seed_artist_idx",
+          "columns": [
+            "user_id",
+            "type",
+            "seed_artist_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "discovery_playlists_user_id_users_user_id_fk": {
+          "name": "discovery_playlists_user_id_users_user_id_fk",
+          "tableFrom": "discovery_playlists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discovery_playlists_seed_artist_id_artists_artist_id_fk": {
+          "name": "discovery_playlists_seed_artist_id_artists_artist_id_fk",
+          "tableFrom": "discovery_playlists",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "seed_artist_id"
+          ],
+          "columnsTo": [
+            "artist_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discovery_playlist_tracks": {
+      "name": "discovery_playlist_tracks",
+      "columns": {
+        "discovery_playlist_track_id": {
+          "name": "discovery_playlist_track_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discovery_playlist_id": {
+          "name": "discovery_playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relevance_score": {
+          "name": "relevance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discovery_playlist_tracks_discovery_playlist_id_discovery_playlists_discovery_playlist_id_fk": {
+          "name": "discovery_playlist_tracks_discovery_playlist_id_discovery_playlists_discovery_playlist_id_fk",
+          "tableFrom": "discovery_playlist_tracks",
+          "tableTo": "discovery_playlists",
+          "columnsFrom": [
+            "discovery_playlist_id"
+          ],
+          "columnsTo": [
+            "discovery_playlist_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discovery_playlist_tracks_track_id_tracks_track_id_fk": {
+          "name": "discovery_playlist_tracks_track_id_tracks_track_id_fk",
+          "tableFrom": "discovery_playlist_tracks",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "track_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "podcasts": {
+      "name": "podcasts",
+      "columns": {
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "podcasts_feed_url_unique": {
+          "name": "podcasts_feed_url_unique",
+          "columns": [
+            "feed_url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "podcast_subscriptions": {
+      "name": "podcast_subscriptions",
+      "columns": {
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "podcast_subscriptions_user_id_users_user_id_fk": {
+          "name": "podcast_subscriptions_user_id_users_user_id_fk",
+          "tableFrom": "podcast_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "podcast_subscriptions_podcast_id_podcasts_podcast_id_fk": {
+          "name": "podcast_subscriptions_podcast_id_podcasts_podcast_id_fk",
+          "tableFrom": "podcast_subscriptions",
+          "tableTo": "podcasts",
+          "columnsFrom": [
+            "podcast_id"
+          ],
+          "columnsTo": [
+            "podcast_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "job_queue": {
+      "name": "job_queue",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "run_after": {
+          "name": "run_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "leased_until": {
+          "name": "leased_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested": {
+          "name": "cancel_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_queue_type_state_run_after_idx": {
+          "name": "job_queue_type_state_run_after_idx",
+          "columns": [
+            "job_type",
+            "state",
+            "run_after"
+          ],
+          "isUnique": false
+        },
+        "job_queue_state_run_after_idx": {
+          "name": "job_queue_state_run_after_idx",
+          "columns": [
+            "state",
+            "run_after"
+          ],
+          "isUnique": false
+        },
+        "job_queue_lease_owner_idx": {
+          "name": "job_queue_lease_owner_idx",
+          "columns": [
+            "lease_owner"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "scan_file_id": {
+          "name": "scan_file_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mtime_ms": {
+          "name": "mtime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extension": {
+          "name": "extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_id_path_unique": {
+          "name": "scan_files_scan_id_path_unique",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "scan_files_scan_id_idx": {
+          "name": "scan_files_scan_id_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scan_runs_scan_id_fk": {
+          "name": "scan_files_scan_id_scan_runs_scan_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scan_runs",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "scan_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_runs": {
+      "name": "scan_runs",
+      "columns": {
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_path": {
+          "name": "root_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "files_discovered": {
+          "name": "files_discovered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_persisted": {
+          "name": "files_persisted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "batches_flushed": {
+          "name": "batches_flushed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_runs_user_state_idx": {
+          "name": "scan_runs_user_state_idx",
+          "columns": [
+            "user_id",
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_runs_job_id_job_queue_job_id_fk": {
+          "name": "scan_runs_job_id_job_queue_job_id_fk",
+          "tableFrom": "scan_runs",
+          "tableTo": "job_queue",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "job_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -5,8 +5,15 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1750851226871,
+      "when": 1771131671687,
       "tag": "0000_sloppy_mole_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1771131671688,
+      "tag": "0002_colossal_christian_walker",
       "breakpoints": true
     }
   ]

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -24,6 +24,7 @@ export * from './discovery-playlists';
 export * from './discovery-playlist-tracks';
 export * from './podcasts';
 export * from './podcast-subscriptions';
+export * from './job-queue';
 
 // Import table objects specifically for defining relations
 import { users } from './users';
@@ -47,6 +48,7 @@ import { discoveryPlaylists } from './discovery-playlists';
 import { discoveryPlaylistTracks } from './discovery-playlist-tracks';
 import { podcasts } from './podcasts';
 import { podcastSubscriptions } from './podcast-subscriptions';
+import { jobQueue, scanRuns, scanFiles } from './job-queue';
 
 // === Relations ===
 
@@ -247,6 +249,21 @@ export const podcastSubscriptionRelations = relations(podcastSubscriptions, ({ o
   user: one(users, {
     fields: [podcastSubscriptions.userId],
     references: [users.userId],
+  }),
+}));
+
+export const scanRunRelations = relations(scanRuns, ({ one, many }) => ({
+  job: one(jobQueue, {
+    fields: [scanRuns.jobId],
+    references: [jobQueue.jobId],
+  }),
+  files: many(scanFiles),
+}));
+
+export const scanFileRelations = relations(scanFiles, ({ one }) => ({
+  scan: one(scanRuns, {
+    fields: [scanFiles.scanId],
+    references: [scanRuns.scanId],
   }),
 }));
 

--- a/server/db/schema/job-queue.ts
+++ b/server/db/schema/job-queue.ts
@@ -1,0 +1,66 @@
+import { sqliteTable, text, integer, index, uniqueIndex } from 'drizzle-orm/sqlite-core';
+import { sql, type InferSelectModel, type InferInsertModel } from 'drizzle-orm';
+import { v7 as uuidv7 } from 'uuid';
+
+export const jobQueue = sqliteTable('job_queue', {
+  jobId: text('job_id').primaryKey().$defaultFn(() => uuidv7()),
+  jobType: text('job_type').notNull(),
+  payload: text('payload').notNull(),
+  state: text('state').notNull().default('queued'),
+  attempts: integer('attempts').notNull().default(0),
+  maxAttempts: integer('max_attempts').notNull().default(3),
+  runAfter: integer('run_after').notNull().default(sql`(unixepoch())`),
+  leasedUntil: integer('leased_until'),
+  leaseOwner: text('lease_owner'),
+  cancelRequested: integer('cancel_requested', { mode: 'boolean' }).notNull().default(false),
+  progress: text('progress'),
+  result: text('result'),
+  lastError: text('last_error'),
+  createdAt: text('created_at').$defaultFn(() => new Date().toISOString()).notNull(),
+  updatedAt: text('updated_at').$defaultFn(() => new Date().toISOString()).notNull(),
+}, (table) => ({
+  jobTypeStateRunAfterIdx: index('job_queue_type_state_run_after_idx').on(table.jobType, table.state, table.runAfter),
+  stateRunAfterIdx: index('job_queue_state_run_after_idx').on(table.state, table.runAfter),
+  leaseOwnerIdx: index('job_queue_lease_owner_idx').on(table.leaseOwner),
+}));
+
+export const scanRuns = sqliteTable('scan_runs', {
+  scanId: text('scan_id').primaryKey(),
+  jobId: text('job_id').notNull().references(() => jobQueue.jobId, { onDelete: 'cascade' }),
+  userId: text('user_id').notNull(),
+  rootPath: text('root_path').notNull(),
+  state: text('state').notNull().default('queued'),
+  filesDiscovered: integer('files_discovered').notNull().default(0),
+  filesPersisted: integer('files_persisted').notNull().default(0),
+  batchesFlushed: integer('batches_flushed').notNull().default(0),
+  errors: integer('errors').notNull().default(0),
+  lastError: text('last_error'),
+  startedAt: text('started_at'),
+  finishedAt: text('finished_at'),
+  cancelledAt: text('cancelled_at'),
+  createdAt: text('created_at').$defaultFn(() => new Date().toISOString()).notNull(),
+  updatedAt: text('updated_at').$defaultFn(() => new Date().toISOString()).notNull(),
+}, (table) => ({
+  scanRunsUserStateIdx: index('scan_runs_user_state_idx').on(table.userId, table.state),
+}));
+
+export const scanFiles = sqliteTable('scan_files', {
+  scanFileId: text('scan_file_id').primaryKey().$defaultFn(() => uuidv7()),
+  scanId: text('scan_id').notNull().references(() => scanRuns.scanId, { onDelete: 'cascade' }),
+  path: text('path').notNull(),
+  sizeBytes: integer('size_bytes'),
+  mtimeMs: integer('mtime_ms'),
+  extension: text('extension'),
+  createdAt: text('created_at').$defaultFn(() => new Date().toISOString()).notNull(),
+  updatedAt: text('updated_at').$defaultFn(() => new Date().toISOString()).notNull(),
+}, (table) => ({
+  scanPathUnique: uniqueIndex('scan_files_scan_id_path_unique').on(table.scanId, table.path),
+  scanIdx: index('scan_files_scan_id_idx').on(table.scanId),
+}));
+
+export type JobQueue = InferSelectModel<typeof jobQueue>;
+export type NewJobQueue = InferInsertModel<typeof jobQueue>;
+export type ScanRun = InferSelectModel<typeof scanRuns>;
+export type NewScanRun = InferInsertModel<typeof scanRuns>;
+export type ScanFile = InferSelectModel<typeof scanFiles>;
+export type NewScanFile = InferInsertModel<typeof scanFiles>;

--- a/server/jobs/README.md
+++ b/server/jobs/README.md
@@ -1,0 +1,26 @@
+# Job Worker
+
+This directory contains a DB-backed queue and worker for long-running background jobs.
+
+## Run in development
+
+```bash
+pnpm tsx server/jobs/worker.ts
+```
+
+## Production recommendation
+
+Run the worker as a separate process/container so scans cannot block Nitro request handling.
+
+## Limits
+
+The worker is guarded by environment-based limits in `server/jobs/limits.ts`:
+- `MAX_CONCURRENT_JOBS`
+- `MAX_CONCURRENT_SCAN_JOBS`
+- `MAX_FS_CONCURRENCY`
+- `MAX_DB_BATCH_SIZE`
+- `MAX_SCAN_DEPTH`
+- `MAX_FILES_PER_SCAN`
+- `MAX_JOB_RUNTIME_MS`
+- `QUEUE_MAX_LENGTH`
+- `QUEUE_MAX_INFLIGHT`

--- a/server/jobs/limits.ts
+++ b/server/jobs/limits.ts
@@ -1,0 +1,38 @@
+export interface JobLimits {
+  maxConcurrentJobs: number;
+  perTypeConcurrency: Record<string, number>;
+  maxDbBatchSize: number;
+  maxFsConcurrency: number;
+  maxScanDepth: number;
+  maxFilesPerScan: number;
+  maxJobRuntimeMs: number;
+  queueMaxLength: number;
+  queueMaxInflight: number;
+  leaseDurationSeconds: number;
+  pollIntervalMs: number;
+}
+
+function envNum(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export function getJobLimits(): JobLimits {
+  return {
+    maxConcurrentJobs: envNum('MAX_CONCURRENT_JOBS', 2),
+    perTypeConcurrency: {
+      'scan.directory': envNum('MAX_CONCURRENT_SCAN_JOBS', 1),
+    },
+    maxDbBatchSize: envNum('MAX_DB_BATCH_SIZE', 500),
+    maxFsConcurrency: envNum('MAX_FS_CONCURRENCY', 8),
+    maxScanDepth: envNum('MAX_SCAN_DEPTH', 32),
+    maxFilesPerScan: envNum('MAX_FILES_PER_SCAN', 200000),
+    maxJobRuntimeMs: envNum('MAX_JOB_RUNTIME_MS', 30 * 60 * 1000),
+    queueMaxLength: envNum('QUEUE_MAX_LENGTH', 1000),
+    queueMaxInflight: envNum('QUEUE_MAX_INFLIGHT', 8),
+    leaseDurationSeconds: envNum('JOB_LEASE_DURATION_SECONDS', 45),
+    pollIntervalMs: envNum('JOB_POLL_INTERVAL_MS', 750),
+  };
+}
+
+export const limits = getJobLimits();

--- a/server/jobs/queue.ts
+++ b/server/jobs/queue.ts
@@ -1,0 +1,140 @@
+import { and, asc, eq, inArray, lt, or, sql } from 'drizzle-orm';
+import { db } from '~/server/db';
+import { jobQueue } from '~/server/db/schema';
+import { limits } from './limits';
+import type { EnqueueJobInput, JobType } from './types';
+import { parsePayloadByType } from './types';
+
+export interface LeasedJob {
+  jobId: string;
+  jobType: JobType;
+  payload: unknown;
+  attempts: number;
+  maxAttempts: number;
+  cancelRequested: boolean;
+}
+
+function nowEpoch() {
+  return Math.floor(Date.now() / 1000);
+}
+
+export async function enqueueJob<T extends JobType>(input: EnqueueJobInput<T>) {
+  const payload = parsePayloadByType(input.type, input.payload);
+  const queuedCount = await db.select({ count: sql<number>`count(*)` }).from(jobQueue).where(eq(jobQueue.state, 'queued'));
+  if ((queuedCount[0]?.count ?? 0) >= limits.queueMaxLength) {
+    return { queued: false as const, reason: 'queue_full' as const };
+  }
+
+  const inserted = await db.insert(jobQueue).values({
+    jobType: input.type,
+    payload: JSON.stringify(payload),
+    state: 'queued',
+    maxAttempts: input.maxAttempts ?? 3,
+    runAfter: input.runAfterEpochSeconds ?? nowEpoch(),
+  }).returning({ jobId: jobQueue.jobId });
+
+  return { queued: true as const, jobId: inserted[0]!.jobId };
+}
+
+export async function leaseNextJob(leaseOwner: string, acceptedTypes: JobType[]): Promise<LeasedJob | null> {
+  const now = nowEpoch();
+  const candidate = await db.select().from(jobQueue)
+    .where(and(
+      inArray(jobQueue.jobType, acceptedTypes),
+      or(
+        and(eq(jobQueue.state, 'queued'), lt(jobQueue.runAfter, now + 1)),
+        and(eq(jobQueue.state, 'running'), lt(jobQueue.leasedUntil, now + 1)),
+      )
+    ))
+    .orderBy(asc(jobQueue.runAfter), asc(jobQueue.createdAt))
+    .limit(1);
+
+  const job = candidate[0];
+  if (!job) return null;
+
+  const leaseUntil = now + limits.leaseDurationSeconds;
+  const updated = await db.update(jobQueue)
+    .set({
+      state: 'running',
+      leaseOwner,
+      leasedUntil: leaseUntil,
+      attempts: sql`${jobQueue.attempts} + 1`,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(and(
+      eq(jobQueue.jobId, job.jobId),
+      or(
+        eq(jobQueue.state, 'queued'),
+        and(eq(jobQueue.state, 'running'), lt(jobQueue.leasedUntil, now + 1))
+      )
+    ))
+    .returning();
+
+  if (!updated[0]) return null;
+
+  return {
+    jobId: job.jobId,
+    jobType: job.jobType as JobType,
+    payload: JSON.parse(job.payload),
+    attempts: (job.attempts ?? 0) + 1,
+    maxAttempts: job.maxAttempts,
+    cancelRequested: Boolean(job.cancelRequested),
+  };
+}
+
+export async function heartbeatLease(jobId: string, leaseOwner: string) {
+  const now = nowEpoch();
+  await db.update(jobQueue).set({ leasedUntil: now + limits.leaseDurationSeconds, updatedAt: new Date().toISOString() })
+    .where(and(eq(jobQueue.jobId, jobId), eq(jobQueue.leaseOwner, leaseOwner), eq(jobQueue.state, 'running')));
+}
+
+export async function markJobProgress(jobId: string, progress: Record<string, unknown>) {
+  await db.update(jobQueue).set({ progress: JSON.stringify(progress), updatedAt: new Date().toISOString() }).where(eq(jobQueue.jobId, jobId));
+}
+
+export async function markJobSucceeded(jobId: string, result: Record<string, unknown>) {
+  await db.update(jobQueue).set({
+    state: 'succeeded',
+    result: JSON.stringify(result),
+    leasedUntil: null,
+    leaseOwner: null,
+    updatedAt: new Date().toISOString(),
+  }).where(eq(jobQueue.jobId, jobId));
+}
+
+export async function markJobCancelled(jobId: string, result: Record<string, unknown> = {}) {
+  await db.update(jobQueue).set({
+    state: 'cancelled',
+    result: JSON.stringify(result),
+    leasedUntil: null,
+    leaseOwner: null,
+    updatedAt: new Date().toISOString(),
+  }).where(eq(jobQueue.jobId, jobId));
+}
+
+export async function markJobFailed(jobId: string, error: Error, attempts: number, maxAttempts: number) {
+  const retryable = attempts < maxAttempts;
+  const nextDelaySec = Math.min(2 ** attempts, 60);
+
+  await db.update(jobQueue).set({
+    state: retryable ? 'queued' : 'failed',
+    runAfter: retryable ? nowEpoch() + nextDelaySec : nowEpoch(),
+    leasedUntil: null,
+    leaseOwner: null,
+    lastError: `${error.name}: ${error.message}`,
+    updatedAt: new Date().toISOString(),
+  }).where(eq(jobQueue.jobId, jobId));
+}
+
+export async function requestJobCancel(jobId: string) {
+  const rows = await db.update(jobQueue)
+    .set({ cancelRequested: true, updatedAt: new Date().toISOString() })
+    .where(and(eq(jobQueue.jobId, jobId), or(eq(jobQueue.state, 'queued'), eq(jobQueue.state, 'running'))))
+    .returning({ jobId: jobQueue.jobId, state: jobQueue.state });
+  return rows[0] ?? null;
+}
+
+export async function getJob(jobId: string) {
+  const rows = await db.select().from(jobQueue).where(eq(jobQueue.jobId, jobId)).limit(1);
+  return rows[0] ?? null;
+}

--- a/server/jobs/types.ts
+++ b/server/jobs/types.ts
@@ -2,9 +2,11 @@ import { z } from 'zod';
 
 export const scanDirectoryJobPayloadSchema = z.object({
   scanId: z.string().min(1),
+  libraryId: z.string().min(1),
   userId: z.string().min(1),
   rootPath: z.string().min(1),
   allowedRoots: z.array(z.string().min(1)).min(1),
+  processOnlyUnprocessed: z.boolean().default(false),
   options: z.object({
     maxDepth: z.number().int().positive().optional(),
     maxFiles: z.number().int().positive().optional(),

--- a/server/jobs/types.ts
+++ b/server/jobs/types.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const scanDirectoryJobPayloadSchema = z.object({
+  scanId: z.string().min(1),
+  userId: z.string().min(1),
+  rootPath: z.string().min(1),
+  allowedRoots: z.array(z.string().min(1)).min(1),
+  options: z.object({
+    maxDepth: z.number().int().positive().optional(),
+    maxFiles: z.number().int().positive().optional(),
+    ignoreDirectories: z.array(z.string()).default([]),
+    ignoreExtensions: z.array(z.string()).default([]),
+  }).default({}),
+});
+
+export const jobPayloadByTypeSchema = {
+  'scan.directory': scanDirectoryJobPayloadSchema,
+} as const;
+
+export type JobType = keyof typeof jobPayloadByTypeSchema;
+export type ScanDirectoryJobPayload = z.infer<typeof scanDirectoryJobPayloadSchema>;
+
+export type JobState = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+
+export interface EnqueueJobInput<T extends JobType> {
+  type: T;
+  payload: z.infer<(typeof jobPayloadByTypeSchema)[T]>;
+  maxAttempts?: number;
+  runAfterEpochSeconds?: number;
+}
+
+export function parsePayloadByType<T extends JobType>(type: T, payload: unknown): z.infer<(typeof jobPayloadByTypeSchema)[T]> {
+  return jobPayloadByTypeSchema[type].parse(payload);
+}

--- a/server/jobs/worker.ts
+++ b/server/jobs/worker.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from 'node:crypto';
+import { limits } from './limits';
+import { getJob, heartbeatLease, leaseNextJob, markJobCancelled, markJobFailed, markJobSucceeded } from './queue';
+import type { JobType } from './types';
+import { parsePayloadByType } from './types';
+import { isJobCancelled, runScanDirectoryJob, syncScanStateFromJob } from '~/server/services/scanner/scan';
+
+type JobHandler = (jobId: string, payload: any, isCancelled: () => Promise<boolean>) => Promise<Record<string, unknown>>;
+
+const handlers: Record<JobType, JobHandler> = {
+  'scan.directory': runScanDirectoryJob,
+};
+
+export class InflightLimiter {
+  private inflight = 0;
+  private byType = new Map<string, number>();
+
+  canRun(jobType: string) {
+    return this.inflight < limits.maxConcurrentJobs && (this.byType.get(jobType) ?? 0) < (limits.perTypeConcurrency[jobType] ?? 1);
+  }
+
+  start(jobType: string) {
+    this.inflight += 1;
+    this.byType.set(jobType, (this.byType.get(jobType) ?? 0) + 1);
+  }
+
+  finish(jobType: string) {
+    this.inflight = Math.max(0, this.inflight - 1);
+    this.byType.set(jobType, Math.max(0, (this.byType.get(jobType) ?? 1) - 1));
+  }
+
+  get count() {
+    return this.inflight;
+  }
+}
+
+async function executeLeasedJob(leaseOwner: string, leased: Awaited<ReturnType<typeof leaseNextJob>>) {
+  if (!leased) return false;
+  const beat = setInterval(() => void heartbeatLease(leased.jobId, leaseOwner), Math.max(5000, limits.pollIntervalMs));
+  try {
+    const payload = parsePayloadByType(leased.jobType, leased.payload);
+    const result = await handlers[leased.jobType](leased.jobId, payload, () => isJobCancelled(leased.jobId));
+
+    if (await isJobCancelled(leased.jobId)) {
+      await markJobCancelled(leased.jobId, result);
+      await syncScanStateFromJob(leased.jobId, 'cancelled');
+    } else {
+      await markJobSucceeded(leased.jobId, result);
+    }
+  } catch (error: any) {
+    await markJobFailed(leased.jobId, error, leased.attempts, leased.maxAttempts);
+    const latest = await getJob(leased.jobId);
+    if (latest?.state === 'failed') {
+      await syncScanStateFromJob(leased.jobId, 'failed', `${error.name}: ${error.message}`);
+    }
+  } finally {
+    clearInterval(beat);
+  }
+  return true;
+}
+
+export async function processSingleJob(leaseOwner = `worker-test-${randomUUID()}`) {
+  for (const type of Object.keys(handlers) as JobType[]) {
+    const leased = await leaseNextJob(leaseOwner, [type]);
+    if (!leased) continue;
+    await executeLeasedJob(leaseOwner, leased);
+    return true;
+  }
+  return false;
+}
+
+export async function runWorkerLoop() {
+  const leaseOwner = `worker-${randomUUID()}`;
+  const limiter = new InflightLimiter();
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (limiter.count >= limits.queueMaxInflight) {
+      await new Promise((resolve) => setTimeout(resolve, limits.pollIntervalMs));
+      continue;
+    }
+
+    let scheduled = false;
+    for (const type of Object.keys(handlers) as JobType[]) {
+      if (!limiter.canRun(type)) continue;
+      const leased = await leaseNextJob(leaseOwner, [type]);
+      if (!leased) continue;
+
+      scheduled = true;
+      limiter.start(type);
+
+      void executeLeasedJob(leaseOwner, leased).finally(() => {
+        limiter.finish(leased.jobType);
+      });
+    }
+
+    if (!scheduled) {
+      await new Promise((resolve) => setTimeout(resolve, limits.pollIntervalMs));
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runWorkerLoop().catch((error) => {
+    console.error('Worker exited due to unhandled error', error);
+    process.exit(1);
+  });
+}

--- a/server/services/scanner/cancel-response.ts
+++ b/server/services/scanner/cancel-response.ts
@@ -1,0 +1,16 @@
+import type { requestJobCancel } from '~/server/jobs/queue';
+
+export function buildCancelResponse(scanId: string, cancelRequest: Awaited<ReturnType<typeof requestJobCancel>>) {
+  if (!cancelRequest) {
+    return {
+      scanId,
+      cancelled: false,
+      reason: 'not_cancellable',
+    } as const;
+  }
+
+  return {
+    scanId,
+    cancelled: true,
+  } as const;
+}

--- a/server/services/scanner/enqueue.ts
+++ b/server/services/scanner/enqueue.ts
@@ -21,9 +21,11 @@ export async function enqueueScanForLibrary(input: z.infer<typeof startScanSchem
     type: 'scan.directory',
     payload: {
       scanId,
+      libraryId: library.mediaFolderId,
       userId,
       rootPath: library.path,
       allowedRoots: [library.path],
+      processOnlyUnprocessed: input.processOnlyUnprocessed,
       options: input.options,
     },
   });

--- a/server/services/scanner/enqueue.ts
+++ b/server/services/scanner/enqueue.ts
@@ -1,0 +1,44 @@
+import { v7 as uuidv7 } from 'uuid';
+import { db } from '~/server/db';
+import { mediaFolders, scanRuns } from '~/server/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { enqueueJob } from '~/server/jobs/queue';
+import type { z } from 'zod';
+import { startScanSchema } from './schemas';
+
+export async function enqueueScanForLibrary(input: z.infer<typeof startScanSchema>, userId: string) {
+  const [library] = await db.select({ mediaFolderId: mediaFolders.mediaFolderId, path: mediaFolders.path })
+    .from(mediaFolders)
+    .where(and(eq(mediaFolders.mediaFolderId, input.libraryId), eq(mediaFolders.userId, userId)))
+    .limit(1);
+
+  if (!library) {
+    throw createError({ statusCode: 404, statusMessage: 'Library not found or access denied.' });
+  }
+
+  const scanId = uuidv7();
+  const enqueue = await enqueueJob({
+    type: 'scan.directory',
+    payload: {
+      scanId,
+      userId,
+      rootPath: library.path,
+      allowedRoots: [library.path],
+      options: input.options,
+    },
+  });
+
+  if (!enqueue.queued) {
+    throw createError({ statusCode: 429, statusMessage: 'Scan queue is full. Please retry later.' });
+  }
+
+  await db.insert(scanRuns).values({
+    scanId,
+    jobId: enqueue.jobId,
+    userId,
+    rootPath: library.path,
+    state: 'queued',
+  });
+
+  return { scanId, jobId: enqueue.jobId, path: library.path };
+}

--- a/server/services/scanner/ingestion.ts
+++ b/server/services/scanner/ingestion.ts
@@ -1,0 +1,22 @@
+import type { ScanStats } from '~/server/utils/scanner/scan-types';
+
+export interface LibraryIngestionInput {
+  libraryId: string;
+  libraryPath: string;
+  userId: string;
+  processOnlyUnprocessed: boolean;
+}
+
+/**
+ * Adapter boundary between the new job pipeline and legacy ingestion logic.
+ * Keeps scan job orchestration decoupled from scanner module internals.
+ */
+export async function runLibraryIngestion(input: LibraryIngestionInput): Promise<ScanStats> {
+  const { scanLibrary } = await import('~/server/utils/scanner');
+  return scanLibrary({
+    libraryId: input.libraryId,
+    libraryPath: input.libraryPath,
+    userId: input.userId,
+    processOnlyUnprocessed: input.processOnlyUnprocessed,
+  });
+}

--- a/server/services/scanner/persist.ts
+++ b/server/services/scanner/persist.ts
@@ -1,0 +1,57 @@
+import { db } from '~/server/db';
+import { scanFiles } from '~/server/db/schema';
+import { sql } from 'drizzle-orm';
+import { limits } from '~/server/jobs/limits';
+import type { WalkEntry } from './walk';
+
+export class ScanBatchWriter {
+  private readonly batchSize: number;
+  private readonly scanId: string;
+  private buffer: WalkEntry[] = [];
+  private persisted = 0;
+  private flushed = 0;
+
+  constructor(scanId: string, batchSize = limits.maxDbBatchSize) {
+    this.scanId = scanId;
+    this.batchSize = Math.min(batchSize, limits.maxDbBatchSize);
+  }
+
+  add(entry: WalkEntry) {
+    this.buffer.push(entry);
+  }
+
+  get size() {
+    return this.buffer.length;
+  }
+
+  get stats() {
+    return { persisted: this.persisted, batchesFlushed: this.flushed };
+  }
+
+  async flush() {
+    if (this.buffer.length === 0) return;
+
+    const batch = this.buffer.splice(0, this.batchSize);
+    await db.insert(scanFiles).values(batch.map((entry) => ({
+      scanId: this.scanId,
+      path: entry.path,
+      sizeBytes: entry.sizeBytes,
+      mtimeMs: entry.mtimeMs,
+      extension: entry.extension,
+      updatedAt: new Date().toISOString(),
+    }))).onConflictDoUpdate({
+      target: [scanFiles.scanId, scanFiles.path],
+      set: {
+        sizeBytes: sql`excluded.size_bytes`,
+        mtimeMs: sql`excluded.mtime_ms`,
+        extension: sql`excluded.extension`,
+        updatedAt: new Date().toISOString(),
+      },
+    });
+
+    this.persisted += batch.length;
+    this.flushed += 1;
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+}

--- a/server/services/scanner/scan.ts
+++ b/server/services/scanner/scan.ts
@@ -7,6 +7,7 @@ import { markJobProgress } from '~/server/jobs/queue';
 import type { ScanDirectoryJobPayload } from '~/server/jobs/types';
 import { walkDirectory } from './walk';
 import { ScanBatchWriter } from './persist';
+import { runLibraryIngestion } from './ingestion';
 
 function isInsideAllowedRoot(candidate: string, allowedRoots: string[]): boolean {
   return allowedRoots.some((root) => candidate === root || candidate.startsWith(`${root}/`));
@@ -64,8 +65,7 @@ export async function runScanDirectoryJob(jobId: string, payload: ScanDirectoryJ
     return { cancelled: true, discovered, ...writer.stats };
   }
 
-  const { scanLibrary } = await import('~/server/utils/scanner');
-  const ingestionStats = await scanLibrary({
+  const ingestionStats = await runLibraryIngestion({
     libraryId: payload.libraryId,
     libraryPath: rootPath,
     userId: payload.userId,

--- a/server/services/scanner/scan.ts
+++ b/server/services/scanner/scan.ts
@@ -1,0 +1,93 @@
+import { realpath } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { and, eq } from 'drizzle-orm';
+import { db } from '~/server/db';
+import { jobQueue, scanRuns } from '~/server/db/schema';
+import { limits } from '~/server/jobs/limits';
+import { markJobProgress } from '~/server/jobs/queue';
+import type { ScanDirectoryJobPayload } from '~/server/jobs/types';
+import { walkDirectory } from './walk';
+import { ScanBatchWriter } from './persist';
+
+function isInsideAllowedRoot(candidate: string, allowedRoots: string[]): boolean {
+  return allowedRoots.some((root) => candidate === root || candidate.startsWith(`${root}/`));
+}
+
+export async function runScanDirectoryJob(jobId: string, payload: ScanDirectoryJobPayload, isCancelled: () => Promise<boolean>) {
+  const startedAt = new Date().toISOString();
+  const rootPath = await realpath(payload.rootPath);
+  const allowedRoots = await Promise.all(payload.allowedRoots.map((path) => realpath(path)));
+
+  if (!isInsideAllowedRoot(rootPath, allowedRoots)) {
+    throw new Error(`Scan path is outside allowed roots: ${rootPath}`);
+  }
+
+  await db.update(scanRuns).set({ state: 'running', startedAt, updatedAt: startedAt }).where(eq(scanRuns.scanId, payload.scanId));
+
+  const writer = new ScanBatchWriter(payload.scanId, limits.maxDbBatchSize);
+  let discovered = 0;
+
+  const started = Date.now();
+  for await (const entry of walkDirectory(rootPath, payload.options)) {
+    if (Date.now() - started > limits.maxJobRuntimeMs) {
+      throw new Error('Scan job exceeded MAX_JOB_RUNTIME_MS');
+    }
+
+    if (await isCancelled()) {
+      await db.update(scanRuns)
+        .set({ state: 'cancelled', cancelledAt: new Date().toISOString(), updatedAt: new Date().toISOString() })
+        .where(eq(scanRuns.scanId, payload.scanId));
+      return { cancelled: true, discovered, ...writer.stats };
+    }
+
+    discovered += 1;
+    writer.add(entry);
+
+    if (writer.size >= limits.maxDbBatchSize) {
+      await writer.flush();
+      const progress = { discovered, ...writer.stats };
+      await markJobProgress(jobId, progress);
+      await db.update(scanRuns).set({
+        filesDiscovered: discovered,
+        filesPersisted: writer.stats.persisted,
+        batchesFlushed: writer.stats.batchesFlushed,
+        updatedAt: new Date().toISOString(),
+      }).where(eq(scanRuns.scanId, payload.scanId));
+    }
+  }
+
+  await writer.flush();
+  const finishedAt = new Date().toISOString();
+  await db.update(scanRuns).set({
+    state: 'succeeded',
+    finishedAt,
+    filesDiscovered: discovered,
+    filesPersisted: writer.stats.persisted,
+    batchesFlushed: writer.stats.batchesFlushed,
+    updatedAt: finishedAt,
+  }).where(eq(scanRuns.scanId, payload.scanId));
+
+  const result = { discovered, ...writer.stats };
+  await markJobProgress(jobId, result);
+  return result;
+}
+
+export async function syncScanStateFromJob(jobId: string, state: 'failed' | 'cancelled', error?: string) {
+  const rows = await db.select({ scanId: scanRuns.scanId }).from(scanRuns).where(eq(scanRuns.jobId, jobId)).limit(1);
+  const scanId = rows[0]?.scanId;
+  if (!scanId) return;
+  await db.update(scanRuns)
+    .set({
+      state,
+      lastError: error,
+      finishedAt: new Date().toISOString(),
+      cancelledAt: state === 'cancelled' ? new Date().toISOString() : null,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(and(eq(scanRuns.scanId, scanId), eq(scanRuns.jobId, jobId)));
+}
+
+export async function isJobCancelled(jobId: string) {
+  const rows = await db.select({ cancelRequested: jobQueue.cancelRequested }).from(jobQueue).where(eq(jobQueue.jobId, jobId)).limit(1);
+  return Boolean(rows[0]?.cancelRequested);
+}

--- a/server/services/scanner/schemas.ts
+++ b/server/services/scanner/schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const startScanSchema = z.object({
   libraryId: z.string().min(1),
+  processOnlyUnprocessed: z.boolean().default(false),
   options: z.object({
     maxDepth: z.number().int().positive().optional(),
     maxFiles: z.number().int().positive().optional(),

--- a/server/services/scanner/schemas.ts
+++ b/server/services/scanner/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const startScanSchema = z.object({
+  libraryId: z.string().min(1),
+  options: z.object({
+    maxDepth: z.number().int().positive().optional(),
+    maxFiles: z.number().int().positive().optional(),
+    ignoreDirectories: z.array(z.string()).default([]),
+    ignoreExtensions: z.array(z.string()).default([]),
+  }).default({}),
+});
+
+export const walkOptionsSchema = z.object({
+  ignoreDirectories: z.array(z.string()).default([]),
+  ignoreExtensions: z.array(z.string()).default([]),
+  maxDepth: z.number().int().positive().optional(),
+  maxFiles: z.number().int().positive().optional(),
+});
+
+export type WalkOptions = z.infer<typeof walkOptionsSchema>;

--- a/server/services/scanner/walk.ts
+++ b/server/services/scanner/walk.ts
@@ -1,0 +1,65 @@
+import { opendir, stat } from 'node:fs/promises';
+import { extname, join } from 'node:path';
+import { limits } from '~/server/jobs/limits';
+import type { WalkOptions } from './schemas';
+
+export interface WalkEntry {
+  path: string;
+  sizeBytes: number | null;
+  mtimeMs: number | null;
+  extension: string | null;
+}
+
+const AUDIO_EXTENSIONS = new Set(['.mp3', '.flac', '.m4a', '.wav', '.ogg', '.opus', '.aac', '.alac']);
+
+export async function* walkDirectory(rootPath: string, options: WalkOptions = {}): AsyncGenerator<WalkEntry> {
+  const ignoreDirectories = new Set(options.ignoreDirectories ?? []);
+  const ignoreExtensions = new Set((options.ignoreExtensions ?? []).map((e) => e.toLowerCase()));
+  const maxDepth = Math.min(options.maxDepth ?? limits.maxScanDepth, limits.maxScanDepth);
+  const maxFiles = Math.min(options.maxFiles ?? limits.maxFilesPerScan, limits.maxFilesPerScan);
+
+  const stack: Array<{ dir: string; depth: number }> = [{ dir: rootPath, depth: 0 }];
+  let emitted = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const dir = await opendir(current.dir);
+
+    for await (const entry of dir) {
+      if (ignoreDirectories.has(entry.name)) {
+        continue;
+      }
+
+      const entryPath = join(current.dir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (current.depth < maxDepth) {
+          stack.push({ dir: entryPath, depth: current.depth + 1 });
+        }
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      const extension = extname(entry.name).toLowerCase();
+      if (!AUDIO_EXTENSIONS.has(extension) || ignoreExtensions.has(extension)) {
+        continue;
+      }
+
+      const info = await stat(entryPath);
+      emitted += 1;
+      yield {
+        path: entryPath,
+        sizeBytes: Number.isFinite(info.size) ? info.size : null,
+        mtimeMs: Number.isFinite(info.mtimeMs) ? Math.trunc(info.mtimeMs) : null,
+        extension,
+      };
+
+      if (emitted >= maxFiles) {
+        return;
+      }
+    }
+  }
+}

--- a/tests/integration/jobs/queue-worker.test.ts
+++ b/tests/integration/jobs/queue-worker.test.ts
@@ -1,0 +1,91 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { db } from '~/server/db';
+import { enqueueJob, requestJobCancel } from '~/server/jobs/queue';
+import { processSingleJob } from '~/server/jobs/worker';
+import { jobQueue, scanFiles, scanRuns } from '~/server/db/schema';
+import { eq } from 'drizzle-orm';
+import { tmpdir } from 'node:os';
+import { readFileSync } from 'node:fs';
+
+const root = fileURLToPath(new URL('../../../', import.meta.url));
+const testDbPath = join(root, 'server', 'tests', 'integration', 'scanner', 'test-db.sqlite');
+
+async function applyMigrations() {
+  const conn = new Database(testDbPath);
+  const migrationDir = join(root, 'server', 'db', 'migrations');
+  const migrationFiles = (await readdir(migrationDir))
+    .filter((name) => /^\d+_.*\.sql$/.test(name))
+    .sort();
+
+  for (const file of migrationFiles) {
+    const sql = readFileSync(join(migrationDir, file), 'utf8').replaceAll('--> statement-breakpoint', '');
+    try { conn.exec(sql); } catch (error: any) { if (!String(error.message).includes('already exists')) throw error; }
+  }
+  conn.close();
+}
+
+describe('queue + worker scan integration', () => {
+  beforeAll(async () => {
+    await mkdir(dirname(testDbPath), { recursive: true });
+    await applyMigrations();
+  });
+
+  beforeEach(async () => {
+    await db.delete(scanFiles);
+    await db.delete(scanRuns);
+    await db.delete(jobQueue);
+  });
+
+  it('processes a queued scan and persists files', async () => {
+    const fixtureDir = await mkdtemp(join(tmpdir(), 'scan-fixture-'));
+    try {
+      await writeFile(join(fixtureDir, 'one.mp3'), '1');
+      await writeFile(join(fixtureDir, 'two.flac'), '2');
+
+      const scanId = 'scan-int-1';
+      const queued = await enqueueJob({
+        type: 'scan.directory',
+        payload: { scanId, userId: 'u1', rootPath: fixtureDir, allowedRoots: [fixtureDir], options: {} },
+      });
+      expect(queued.queued).toBe(true);
+
+      await db.insert(scanRuns).values({ scanId, jobId: queued.jobId!, userId: 'u1', rootPath: fixtureDir, state: 'queued' });
+
+      await processSingleJob();
+
+      const rows = await db.select().from(scanFiles).where(eq(scanFiles.scanId, scanId));
+      expect(rows.length).toBe(2);
+
+      const [scan] = await db.select().from(scanRuns).where(eq(scanRuns.scanId, scanId)).limit(1);
+      expect(scan?.state).toBe('succeeded');
+      expect(scan?.filesPersisted).toBe(2);
+    } finally {
+      await rm(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('cancellation marks run cancelled and stops work', async () => {
+    const fixtureDir = await mkdtemp(join(tmpdir(), 'scan-fixture-cancel-'));
+    try {
+      await writeFile(join(fixtureDir, 'one.mp3'), '1');
+      const scanId = 'scan-int-cancel';
+      const queued = await enqueueJob({
+        type: 'scan.directory',
+        payload: { scanId, userId: 'u1', rootPath: fixtureDir, allowedRoots: [fixtureDir], options: {} },
+      });
+      await db.insert(scanRuns).values({ scanId, jobId: queued.jobId!, userId: 'u1', rootPath: fixtureDir, state: 'queued' });
+      await requestJobCancel(queued.jobId!);
+
+      await processSingleJob();
+
+      const [scan] = await db.select().from(scanRuns).where(eq(scanRuns.scanId, scanId)).limit(1);
+      expect(scan?.state).toBe('cancelled');
+    } finally {
+      await rm(fixtureDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/integration/jobs/queue-worker.test.ts
+++ b/tests/integration/jobs/queue-worker.test.ts
@@ -11,8 +11,8 @@ import { eq } from 'drizzle-orm';
 import { tmpdir } from 'node:os';
 import { readFileSync } from 'node:fs';
 
-vi.mock('~/server/utils/scanner', () => ({
-  scanLibrary: vi.fn().mockResolvedValue({
+vi.mock('~/server/services/scanner/ingestion', () => ({
+  runLibraryIngestion: vi.fn().mockResolvedValue({
     scannedFiles: 2,
     addedTracks: 2,
     addedArtists: 1,

--- a/tests/setup-node.ts
+++ b/tests/setup-node.ts
@@ -1,0 +1,5 @@
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+mkdirSync(join(process.cwd(), 'server', 'tests', 'integration', 'scanner'), { recursive: true });
+process.env.NODE_ENV = 'test';

--- a/tests/setup-node.ts
+++ b/tests/setup-node.ts
@@ -3,3 +3,8 @@ import { join } from 'node:path';
 
 mkdirSync(join(process.cwd(), 'server', 'tests', 'integration', 'scanner'), { recursive: true });
 process.env.NODE_ENV = 'test';
+
+// Minimal Nuxt runtime shim for server utilities imported in node-only tests.
+(globalThis as any).useRuntimeConfig = () => ({
+  musicbrainzUserAgent: 'lyra-test/1.0',
+});

--- a/tests/setup-node.ts
+++ b/tests/setup-node.ts
@@ -3,8 +3,3 @@ import { join } from 'node:path';
 
 mkdirSync(join(process.cwd(), 'server', 'tests', 'integration', 'scanner'), { recursive: true });
 process.env.NODE_ENV = 'test';
-
-// Minimal Nuxt runtime shim for server utilities imported in node-only tests.
-(globalThis as any).useRuntimeConfig = () => ({
-  musicbrainzUserAgent: 'lyra-test/1.0',
-});

--- a/tests/unit/jobs/limiter.test.ts
+++ b/tests/unit/jobs/limiter.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { InflightLimiter } from '~/server/jobs/worker';
+
+describe('InflightLimiter', () => {
+  it('tracks global and per-type slots', () => {
+    const limiter = new InflightLimiter();
+
+    limiter.start('scan.directory');
+    expect(limiter.count).toBe(1);
+
+    limiter.finish('scan.directory');
+    expect(limiter.count).toBe(0);
+  });
+});

--- a/tests/unit/scanner/cancel-response.test.ts
+++ b/tests/unit/scanner/cancel-response.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { buildCancelResponse } from '~/server/services/scanner/cancel-response';
+
+describe('buildCancelResponse', () => {
+  it('returns cancelled=false when job is not cancellable', () => {
+    expect(buildCancelResponse('scan-1', null)).toEqual({
+      scanId: 'scan-1',
+      cancelled: false,
+      reason: 'not_cancellable',
+    });
+  });
+
+  it('returns cancelled=true when cancellation was requested', () => {
+    expect(buildCancelResponse('scan-1', { jobId: 'job-1', state: 'running' as const })).toEqual({
+      scanId: 'scan-1',
+      cancelled: true,
+    });
+  });
+});

--- a/tests/unit/scanner/persist.test.ts
+++ b/tests/unit/scanner/persist.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { ScanBatchWriter } from '~/server/services/scanner/persist';
+
+describe('ScanBatchWriter', () => {
+  it('buffers entries before flush', () => {
+    const writer = new ScanBatchWriter('scan-test', 2);
+    writer.add({ path: '/tmp/a.mp3', sizeBytes: 1, mtimeMs: 1, extension: '.mp3' });
+    expect(writer.size).toBe(1);
+  });
+});

--- a/tests/unit/scanner/scan-job-handler.test.ts
+++ b/tests/unit/scanner/scan-job-handler.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const updateMock = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) }));
+const selectMock = vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([{ cancelRequested: false }]) })) })) }));
+
+vi.mock('~/server/db', () => ({
+  db: {
+    update: updateMock,
+    select: selectMock,
+  },
+}));
+
+vi.mock('~/server/jobs/queue', () => ({
+  markJobProgress: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/scanner/persist', () => ({
+  ScanBatchWriter: class {
+    private entries: any[] = [];
+    add(entry: any) { this.entries.push(entry); }
+    get size() { return this.entries.length; }
+    get stats() { return { persisted: this.entries.length, batchesFlushed: this.entries.length ? 1 : 0 }; }
+    async flush() {}
+    constructor(_scanId: string, _batch: number) {}
+  },
+}));
+
+const scanLibraryMock = vi.fn().mockResolvedValue({
+  scannedFiles: 1,
+  addedTracks: 1,
+  addedArtists: 1,
+  addedAlbums: 1,
+  skippedFiles: 0,
+  errors: 0,
+});
+
+vi.mock('~/server/utils/scanner', () => ({
+  scanLibrary: scanLibraryMock,
+}));
+
+describe('runScanDirectoryJob ingestion flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('invokes scanLibrary ingestion before marking success', async () => {
+    const { runScanDirectoryJob } = await import('~/server/services/scanner/scan');
+    const root = await mkdtemp(join(tmpdir(), 'scan-job-handler-'));
+    try {
+      await writeFile(join(root, 'one.mp3'), '1');
+      const result = await runScanDirectoryJob('job-1', {
+        scanId: 'scan-1',
+        libraryId: 'lib-1',
+        userId: 'user-1',
+        rootPath: root,
+        allowedRoots: [root],
+        processOnlyUnprocessed: true,
+        options: {},
+      }, async () => false);
+
+      expect(scanLibraryMock).toHaveBeenCalledWith({
+        libraryId: 'lib-1',
+        libraryPath: root,
+        userId: 'user-1',
+        processOnlyUnprocessed: true,
+      });
+      expect((result as any).ingestionStats.addedTracks).toBe(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/scanner/scan-job-handler.test.ts
+++ b/tests/unit/scanner/scan-job-handler.test.ts
@@ -28,7 +28,7 @@ vi.mock('~/server/services/scanner/persist', () => ({
   },
 }));
 
-const scanLibraryMock = vi.fn().mockResolvedValue({
+const runLibraryIngestionMock = vi.fn().mockResolvedValue({
   scannedFiles: 1,
   addedTracks: 1,
   addedArtists: 1,
@@ -37,8 +37,8 @@ const scanLibraryMock = vi.fn().mockResolvedValue({
   errors: 0,
 });
 
-vi.mock('~/server/utils/scanner', () => ({
-  scanLibrary: scanLibraryMock,
+vi.mock('~/server/services/scanner/ingestion', () => ({
+  runLibraryIngestion: runLibraryIngestionMock,
 }));
 
 describe('runScanDirectoryJob ingestion flow', () => {
@@ -61,7 +61,7 @@ describe('runScanDirectoryJob ingestion flow', () => {
         options: {},
       }, async () => false);
 
-      expect(scanLibraryMock).toHaveBeenCalledWith({
+      expect(runLibraryIngestionMock).toHaveBeenCalledWith({
         libraryId: 'lib-1',
         libraryPath: root,
         userId: 'user-1',

--- a/tests/unit/scanner/walk.test.ts
+++ b/tests/unit/scanner/walk.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { walkDirectory } from '~/server/services/scanner/walk';
+
+describe('walkDirectory', () => {
+  it('respects ignore rules and maxFiles', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'scan-walk-'));
+    try {
+      await writeFile(join(root, 'a.mp3'), 'a');
+      await writeFile(join(root, 'skip.txt'), 'x');
+      const ignored = join(root, 'ignored');
+      await mkdir(ignored);
+      await writeFile(join(ignored, 'b.flac'), 'b');
+
+      const found: string[] = [];
+      for await (const entry of walkDirectory(root, { ignoreDirectories: ['ignored'], maxFiles: 1 })) {
+        found.push(entry.path.replace(`${root}/`, ''));
+      }
+
+      expect(found).toEqual(['a.mp3']);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/vitest.node.config.ts
+++ b/vitest.node.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: ['./tests/setup-node.ts'],
+  },
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
### Motivation
- Address a review that migrations must be generated from the schema via Drizzle Kit instead of being hand-edited to avoid drift and maintain proper migration snapshots. 
- Ensure the scan job DB schema (queue + scan_runs + scan_files) is represented by a Drizzle-generated migration and snapshot for reliable dev/test workflows. 
- Make integration tests resilient to migration filename changes by applying all SQL migrations dynamically during test bootstrap. 

### Description
- Regenerated the scan/job migration using Drizzle Kit which produced `server/db/migrations/0002_colossal_christian_walker.sql` and the matching snapshot `server/db/migrations/meta/0002_snapshot.json`. 
- Removed the previously hand-authored migration from the active chain and updated `server/db/migrations/meta/_journal.json` to reference the generated artifact. 
- Hardened the integration migration bootstrap in `tests/integration/jobs/queue-worker.test.ts` to load and apply all `*.sql` files from the migrations directory and tolerate already-existing objects, preventing brittleness when Drizzle names migrations differently. 

### Testing
- Ran schema generation with `DATABASE_URL=./db.sqlite pnpm db:generate` which produced the Drizzle migration (no further schema drift). 
- Ran the test subset with `pnpm vitest run --config vitest.node.config.ts tests/unit/scanner/walk.test.ts tests/unit/jobs/limiter.test.ts tests/unit/scanner/persist.test.ts tests/integration/jobs/queue-worker.test.ts` and all tests passed. 
- Verified the integration bootstrap creates the test DB and applies migrations such that the worker+queue integration tests succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914d694ee88326aaad29498888c110)