### PR TITLE
fix(frontend): harden auth cookies, sanitize redirects, and add lazy fetch policies

### DIFF
--- a/components/playlist/playlist-card.utils.ts
+++ b/components/playlist/playlist-card.utils.ts
@@ -1,0 +1,4 @@
+export const formatPlaylistTrackCount = (count: number | undefined): string => {
+  if (count === undefined) return '0 tracks'
+  return count === 1 ? '1 track' : `${count} tracks`
+}

--- a/components/playlist/playlist-card.vue
+++ b/components/playlist/playlist-card.vue
@@ -24,7 +24,7 @@
     <div class="card-body p-4">
       <h2 class="card-title text-base truncate">{{ playlist.name }}</h2>
       <p class="text-sm text-base-content/70">
-        {{ formatTrackCount(playlist.trackCount) }}
+        {{ formatPlaylistTrackCount(playlist.trackCount) }}
       </p>
       <div class="card-actions justify-end mt-2">
         <div class="dropdown dropdown-end">
@@ -55,8 +55,5 @@ defineEmits<{
   (e: 'delete', id: string): void;
 }>();
 
-const formatTrackCount = (count: number): string => {
-  if (count === undefined) return '0 tracks';
-  return count === 1 ? '1 track' : `${count} tracks`;
-};
+import { formatPlaylistTrackCount } from '~/components/playlist/playlist-card.utils';
 </script>

--- a/composables/use-fetch-policy.ts
+++ b/composables/use-fetch-policy.ts
@@ -1,0 +1,19 @@
+export type FetchPolicy = 'ssr-required' | 'lazy-ok' | 'user-triggered'
+
+interface PolicyOptions {
+  server?: boolean
+}
+
+export const resolveFetchPolicyOptions = (policy: FetchPolicy, options: PolicyOptions = {}) => {
+  const server = options.server ?? true
+
+  if (policy === 'ssr-required') {
+    return { lazy: false, server, immediate: true }
+  }
+
+  if (policy === 'lazy-ok') {
+    return { lazy: true, server: false, immediate: true }
+  }
+
+  return { lazy: true, server: false, immediate: false }
+}

--- a/docs/refactor/frontend_BASELINE.md
+++ b/docs/refactor/frontend_BASELINE.md
@@ -1,0 +1,42 @@
+# Frontend Refactor Baseline (Nuxt 3 SSR + Client)
+
+## SSR / hydration issues found
+
+- `server/api/auth/login.post.ts`: password verification result was treated as a boolean object, allowing invalid passwords to pass (`if (!isPasswordValid)` with `{ success }` object). Root-cause auth/security bug affecting SSR-protected routes indirectly.
+- `pages/radio/[id].vue`: ownership check read `user.value.user.id` while `/api/auth/me` returns `{ userId, ... }`, so owner-only UI never appears.
+- `middleware/session.global.ts`: redirects to login without preserving intent, and no redirect sanitization existed for post-login return.
+- `server/middleware/auth.ts`, `server/api/auth/login.post.ts`, `server/api/auth/register.post.ts`, `server/utils/auth.ts`: cookie policy was duplicated and hard-coded (`secure: true`, `sameSite: strict`) without environment-aware behavior or consistent clear semantics.
+
+## Cookie/auth handling map
+
+- Set auth cookie:
+  - `server/api/auth/login.post.ts`
+  - `server/api/auth/register.post.ts`
+- Read auth cookie:
+  - `server/utils/auth.ts` (`getUserFromEvent`)
+  - `server/middleware/auth.ts`
+- Clear auth cookie:
+  - `server/api/auth/logout.post.ts` -> `server/utils/auth.ts::clearToken`
+  - `server/middleware/auth.ts` (invalid token cleanup)
+- Client auth state:
+  - `composables/use-user.ts` (`useState('user')`)
+  - `stores/auth.ts` (duplicate auth state path; potential drift)
+
+## Data loading classification checklist
+
+### SSR-required
+- Detail pages where first paint and SEO rely on content title/body (`pages/albums/[id].vue`, `pages/artists/[id].vue`, `pages/podcasts/[id].vue`, `pages/discovery/[id].vue`, `pages/playlists/[id].vue`, `pages/radio/[id].vue` station metadata).
+
+### Lazy-ok
+- Session user profile fetch for UI affordances only (`/api/auth/me` usage in radio details).
+- Secondary collections that are not above-the-fold for SEO.
+
+### User-triggered
+- Radio track queue for playback (`/api/radio-stations/:id/tracks`) fetched only when play/next interaction occurs.
+
+## Prioritized checklist
+
+1. Fix auth verification bug and centralize cookie policy (security + correctness).
+2. Add redirect sanitization and safe post-login return flow.
+3. Move non-critical data fetches to lazy/user-triggered policy to reduce SSR payload.
+4. Add focused tests for fetch policy, cookie/session derivation, redirect sanitizer, SSR deterministic component render.

--- a/docs/refactor/frontend_PLAN.md
+++ b/docs/refactor/frontend_PLAN.md
@@ -1,0 +1,25 @@
+# Frontend Refactor Plan
+
+## Phase 1: Auth + cookie correctness
+- **Intent:** eliminate auth bypass risk and normalize cookie attributes.
+- **Files:** `server/api/auth/login.post.ts`, `server/api/auth/register.post.ts`, `server/utils/auth.ts`, `server/middleware/auth.ts`, `server/utils/auth-cookie.ts`, `server/utils/auth-session.ts`.
+- **Risks:** login/register response shape changed (token removed from body).
+- **Tests:** unit test for session derivation; auth route smoke via existing integration tests where applicable.
+
+## Phase 2: Redirect hardening
+- **Intent:** prevent open redirect and preserve valid in-app return path.
+- **Files:** `utils/redirect.ts`, `middleware/session.global.ts`, `pages/login.vue`.
+- **Risks:** invalid/unknown redirect params now fall back to `/library`.
+- **Tests:** unit tests for redirect sanitizer edge cases.
+
+## Phase 3: Lazy retrieval tightening
+- **Intent:** reduce initial payload on radio detail by deferring non-critical and interaction-based calls.
+- **Files:** `composables/use-fetch-policy.ts`, `pages/radio/[id].vue`.
+- **Risks:** first play may incur loading delay; mitigated by pending state.
+- **Tests:** unit tests for fetch policy decisions.
+
+## Phase 4: SSR determinism guard
+- **Intent:** ensure critical visual card renders deterministically in SSR.
+- **Files:** `tests/component/playlist-card-formatting.test.ts`.
+- **Risks:** none.
+- **Tests:** deterministic component-facing formatting assertions used by playlist card rendering.

--- a/middleware/session.global.ts
+++ b/middleware/session.global.ts
@@ -1,4 +1,5 @@
 import { useUser } from '~/composables/use-user';
+import { sanitizeRedirectPath } from '~/utils/redirect';
 
 /**
  * Session middleware that checks if the user is authenticated via server session
@@ -20,7 +21,7 @@ export default defineNuxtRouteMiddleware(async (to, event) => {
     if (!user) {
       return navigateTo({
         path: '/login',
-        query: { invalid: 'true' }
+        query: { invalid: 'true', redirect: sanitizeRedirectPath(to.fullPath) }
       });
     }
     
@@ -29,7 +30,7 @@ export default defineNuxtRouteMiddleware(async (to, event) => {
     if (error?.response?.status === 401 || error?.statusCode === 401) {
       return navigateTo({
         path: '/login',
-        query: { invalid: 'true' }
+        query: { invalid: 'true', redirect: sanitizeRedirectPath(to.fullPath) }
       });
     }
     // For other errors, still redirect to login for safety

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -63,6 +63,7 @@
 <script setup lang="ts">
 import { z } from 'zod'
 import { useUser } from '~/composables/use-user'
+import { sanitizeRedirectPath } from '~/utils/redirect'
 
 const loginSchema = z.object({
   email: z.string().email('Invalid email format'),
@@ -81,6 +82,7 @@ const state = reactive<LoginSchema>({
   password: ''
 })
 
+const route = useRoute()
 const loading = ref(false)
 const errorMessage = ref<string | null>(null)
 const validationErrors = ref<ValidationError>({})
@@ -104,7 +106,7 @@ async function login() {
   }
 
   try {
-    const response = await $fetch('/api/auth/login', {
+    await $fetch('/api/auth/login', {
       method: 'POST',
       body: JSON.stringify(result.data) // Use validated data
     })
@@ -114,8 +116,8 @@ async function login() {
     const { fetchUser } = useUser();
     await fetchUser();
     
-    // Redirect to the libraries page upon successful login
-    await navigateTo('/library');
+    const redirectTarget = sanitizeRedirectPath(route.query.redirect as string | undefined)
+    await navigateTo(redirectTarget);
   } catch (error: any) {
     if (error.data && error.data.message) {
       errorMessage.value = error.data.message

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,15 +1,17 @@
 import { defineEventHandler, createError, parseCookies, getHeader, setCookie } from 'h3';
 import { getUserFromEvent, verifyToken } from '../utils/auth';
+import { AUTH_COOKIE_NAME, getExpiredAuthCookieOptions } from '~/server/utils/auth-cookie';
+import { deriveSessionUserFromToken } from '~/server/utils/auth-session';
 
 // Authentication middleware
 export default defineEventHandler(async (event) => {
   // Skip authentication for public routes
   const path = event.path || '';
-  
+
   // Public paths that should not require authentication
   const publicPaths = ['/api/auth', '/api/health'];
   const publicPages = ['/login', '/register'];
-  
+
   // Skip auth check for non-API routes and explicitly allowed public paths
   if (!path.startsWith('/api') || publicPaths.some(p => path.startsWith(p)) || publicPages.some(p => path === p)) {
     return;
@@ -17,60 +19,24 @@ export default defineEventHandler(async (event) => {
 
   // Check if user is authenticated
   let user = await getUserFromEvent(event);
-  
+
   // If no user is found in the event, try multiple auth methods
   if (!user) {
-    // Method 1: Check for auth_token cookie
     const cookies = parseCookies(event);
-    const cookieToken = cookies['auth_token'];
-    
-    // Method 2: Check for Authorization header with Bearer token
+    const cookieToken = cookies[AUTH_COOKIE_NAME];
+
     const authHeader = getHeader(event, 'authorization');
-    const bearerToken = authHeader && authHeader.startsWith('Bearer ') 
-      ? authHeader.substring(7) 
+    const bearerToken = authHeader && authHeader.startsWith('Bearer ')
+      ? authHeader.substring(7)
       : null;
-    
-    // Use either cookie token or bearer token
-    const authToken = cookieToken || bearerToken;
-    
-    if (authToken) {
-      try {
-        // Verify the JWT token
-        const userData = verifyToken(authToken);
 
-        if (!userData?.iat || !userData.exp || userData.exp < Date.now() / 1000) {
-          setCookie(event, 'auth_token', '', {
-            httpOnly: true,
-            secure: true,
-            sameSite: 'strict',
-            maxAge: 0
-          });
-          throw createError({
-            statusCode: 401,
-            message: 'Unauthorized: Invalid token'
-          });
-        }
+    user = deriveSessionUserFromToken(cookieToken || bearerToken, verifyToken);
 
-        if (userData && userData.userId) {
-          // Create a user object from the token data
-          user = {
-            userId: userData.userId,
-            name: userData.name || '',
-            email: userData.email || '',
-          };
-        }
-      } catch (e) {
-        // Token verification failed - clear invalid cookie
-        setCookie(event, 'auth_token', '', {
-          httpOnly: true,
-          secure: true,
-          sameSite: 'strict',
-          maxAge: 0
-        });
-      }
+    if (!user && cookieToken) {
+      setCookie(event, AUTH_COOKIE_NAME, '', getExpiredAuthCookieOptions(event));
     }
   }
-  
+
   // If still no user, throw unauthorized error
   if (!user) {
     throw createError({

--- a/server/utils/auth-cookie.ts
+++ b/server/utils/auth-cookie.ts
@@ -1,0 +1,22 @@
+import type { H3Event, CookieSerializeOptions } from 'h3'
+
+export const AUTH_COOKIE_NAME = 'auth_token'
+export const AUTH_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 7
+
+export const getAuthCookieOptions = (_event: H3Event): CookieSerializeOptions => {
+  const isProduction = process.env.NODE_ENV === 'production'
+
+  return {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: AUTH_COOKIE_MAX_AGE_SECONDS,
+  }
+}
+
+export const getExpiredAuthCookieOptions = (event: H3Event): CookieSerializeOptions => ({
+  ...getAuthCookieOptions(event),
+  maxAge: 0,
+  expires: new Date(0),
+})

--- a/server/utils/auth-session.ts
+++ b/server/utils/auth-session.ts
@@ -1,0 +1,28 @@
+import type { User } from '~/types/user'
+
+export interface SessionUser {
+  userId: string
+  name: string
+  email: string
+}
+
+export const deriveSessionUserFromToken = (token: string | null | undefined, verifier: (token: string) => User | null): SessionUser | null => {
+  if (!token) {
+    return null
+  }
+
+  const decoded = verifier(token)
+  if (!decoded?.userId || !decoded?.email || !decoded?.name) {
+    return null
+  }
+
+  if (decoded.exp && Date.now() / 1000 > decoded.exp) {
+    return null
+  }
+
+  return {
+    userId: decoded.userId,
+    name: decoded.name,
+    email: decoded.email,
+  }
+}

--- a/tests/component/playlist-card-formatting.test.ts
+++ b/tests/component/playlist-card-formatting.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { formatPlaylistTrackCount } from '~/components/playlist/playlist-card.utils'
+
+describe('playlist-card formatting', () => {
+  it('formats track counts deterministically', () => {
+    expect(formatPlaylistTrackCount(undefined)).toBe('0 tracks')
+    expect(formatPlaylistTrackCount(1)).toBe('1 track')
+    expect(formatPlaylistTrackCount(42)).toBe('42 tracks')
+  })
+})

--- a/tests/unit/frontend/auth-session.test.ts
+++ b/tests/unit/frontend/auth-session.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { deriveSessionUserFromToken } from '~/server/utils/auth-session'
+
+describe('deriveSessionUserFromToken', () => {
+  it('returns a session user for a valid token payload', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const user = deriveSessionUserFromToken('token', () => ({
+      userId: 'u1',
+      name: 'Ada',
+      email: 'ada@example.com',
+      exp: now + 600,
+    }))
+
+    expect(user).toEqual({ userId: 'u1', name: 'Ada', email: 'ada@example.com' })
+  })
+
+  it('returns null when payload is expired or invalid', () => {
+    const now = Math.floor(Date.now() / 1000)
+    expect(deriveSessionUserFromToken('token', () => ({
+      userId: 'u1',
+      name: 'Ada',
+      email: 'ada@example.com',
+      exp: now - 10,
+    }))).toBeNull()
+
+    expect(deriveSessionUserFromToken('token', () => null)).toBeNull()
+    expect(deriveSessionUserFromToken(undefined, () => null)).toBeNull()
+  })
+})

--- a/tests/unit/frontend/fetch-policy.test.ts
+++ b/tests/unit/frontend/fetch-policy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { resolveFetchPolicyOptions } from '~/composables/use-fetch-policy'
+
+describe('resolveFetchPolicyOptions', () => {
+  it('uses eager SSR for ssr-required', () => {
+    expect(resolveFetchPolicyOptions('ssr-required')).toEqual({ lazy: false, server: true, immediate: true })
+  })
+
+  it('uses lazy client fetch for lazy-ok', () => {
+    expect(resolveFetchPolicyOptions('lazy-ok')).toEqual({ lazy: true, server: false, immediate: true })
+  })
+
+  it('uses explicit execution for user-triggered', () => {
+    expect(resolveFetchPolicyOptions('user-triggered')).toEqual({ lazy: true, server: false, immediate: false })
+  })
+})

--- a/tests/unit/frontend/redirect.test.ts
+++ b/tests/unit/frontend/redirect.test.ts
@@ -7,6 +7,12 @@ describe('sanitizeRedirectPath', () => {
     expect(sanitizeRedirectPath('/playlists/abc')).toBe('/playlists/abc')
   })
 
+  it('preserves query strings and hashes for whitelisted routes', () => {
+    expect(sanitizeRedirectPath('/tracks?albumId=abc')).toBe('/tracks?albumId=abc')
+    expect(sanitizeRedirectPath('/tracks?albumId=abc#queue')).toBe('/tracks?albumId=abc#queue')
+    expect(sanitizeRedirectPath('/playlists/abc?view=compact')).toBe('/playlists/abc?view=compact')
+  })
+
   it('rejects absolute and protocol-relative redirects', () => {
     expect(sanitizeRedirectPath('https://evil.com')).toBe('/library')
     expect(sanitizeRedirectPath('//evil.com/pwn')).toBe('/library')

--- a/tests/unit/frontend/redirect.test.ts
+++ b/tests/unit/frontend/redirect.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeRedirectPath } from '~/utils/redirect'
+
+describe('sanitizeRedirectPath', () => {
+  it('allows safe in-app paths', () => {
+    expect(sanitizeRedirectPath('/library')).toBe('/library')
+    expect(sanitizeRedirectPath('/playlists/abc')).toBe('/playlists/abc')
+  })
+
+  it('rejects absolute and protocol-relative redirects', () => {
+    expect(sanitizeRedirectPath('https://evil.com')).toBe('/library')
+    expect(sanitizeRedirectPath('//evil.com/pwn')).toBe('/library')
+  })
+
+  it('rejects unknown or malformed paths', () => {
+    expect(sanitizeRedirectPath('/admin')).toBe('/library')
+    expect(sanitizeRedirectPath('/radio\\evil')).toBe('/library')
+    expect(sanitizeRedirectPath(undefined)).toBe('/library')
+  })
+})

--- a/utils/redirect.ts
+++ b/utils/redirect.ts
@@ -1,0 +1,22 @@
+const SAFE_REDIRECT_PATH = '/library'
+
+const ALLOWED_REDIRECT_PREFIXES = ['/library', '/albums', '/artists', '/genres', '/playlists', '/discovery', '/radio', '/podcasts', '/settings', '/tracks']
+
+export const sanitizeRedirectPath = (rawRedirect: string | null | undefined): string => {
+  if (!rawRedirect) {
+    return SAFE_REDIRECT_PATH
+  }
+
+  if (!rawRedirect.startsWith('/') || rawRedirect.startsWith('//')) {
+    return SAFE_REDIRECT_PATH
+  }
+
+  if (rawRedirect.includes('\\')) {
+    return SAFE_REDIRECT_PATH
+  }
+
+  return ALLOWED_REDIRECT_PREFIXES.some((prefix) => rawRedirect === prefix || rawRedirect.startsWith(`${prefix}/`))
+    ? rawRedirect
+    : SAFE_REDIRECT_PATH
+}
+

--- a/utils/redirect.ts
+++ b/utils/redirect.ts
@@ -15,8 +15,10 @@ export const sanitizeRedirectPath = (rawRedirect: string | null | undefined): st
     return SAFE_REDIRECT_PATH
   }
 
-  return ALLOWED_REDIRECT_PREFIXES.some((prefix) => rawRedirect === prefix || rawRedirect.startsWith(`${prefix}/`))
-    ? rawRedirect
+  const parsed = new URL(rawRedirect, 'http://localhost')
+  const sanitizedPath = `${parsed.pathname}${parsed.search}${parsed.hash}`
+
+  return ALLOWED_REDIRECT_PREFIXES.some((prefix) => parsed.pathname === prefix || parsed.pathname.startsWith(`${prefix}/`))
+    ? sanitizedPath
     : SAFE_REDIRECT_PATH
 }
-

--- a/vitest.frontend.config.ts
+++ b/vitest.frontend.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/unit/frontend/**/*.test.ts', 'tests/component/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+})


### PR DESCRIPTION
### Motivation

- Fix an authentication correctness/security bug where password verification result was misinterpreted and unify cookie handling to avoid leaking secrets into client bundles. 
- Prevent open-redirect and preserve safe post-login return behavior for session middleware and login flow. 
- Reduce SSR payload/hydration risk by deferring non-critical data (radio track lists and session-affordance calls) to client-triggered or lazy fetch strategies. 
- Remove small duplicated logic and make UI rendering deterministic where possible (formatting helper for playlist card).

### Description

- Centralized cookie/session behavior: added `server/utils/auth-cookie.ts` and `server/utils/auth-session.ts` and updated `server/utils/auth.ts`, `server/middleware/auth.ts`, `server/api/auth/login.post.ts`, and `server/api/auth/register.post.ts` to use the shared cookie name/options and session derivation helper and to clear cookies using a single policy (`httpOnly`, `sameSite: 'lax'`, `secure` in production, explicit `maxAge`).
- Fixed verification bug by checking `verification.success` from `verifyPassword` in `server/api/auth/login.post.ts` so failed password checks cannot pass silently. 
- Hardening redirects: added `utils/redirect.ts` with an allowlist and used it from `middleware/session.global.ts` and `pages/login.vue` to sanitize `redirect` return targets and fall back to `/library` for unsafe values. 
- Lazy fetch policy and usage: added `composables/use-fetch-policy.ts` and applied it to `pages/radio/[id].vue` so `tracks` are fetched with `execute()` only on user interaction and `user` session info is fetched lazily for UI affordances. 
- Small duplication cleanup: extracted playlist track-count formatter into `components/playlist/playlist-card.utils.ts` and updated `components/playlist/playlist-card.vue` to use it. 
- Tests and test config: added focused node-scoped tests and a lightweight Vitest config `vitest.frontend.config.ts` covering redirect sanitizer, session derivation, fetch-policy decision logic, and playlist formatting; tests added under `tests/unit/frontend/*` and `tests/component/*`. 

### Testing

- Ran node-focused test suite with a dedicated config using `pnpm vitest run -c vitest.frontend.config.ts`, which executed: `tests/unit/frontend/redirect.test.ts`, `tests/unit/frontend/auth-session.test.ts`, `tests/unit/frontend/fetch-policy.test.ts`, and `tests/component/playlist-card-formatting.test.ts` and all tests passed. 
- Attempted a full Nuxt-environment Vitest run which failed in this environment due to inability to fetch remote font providers and a missing test runtime dependency (`happy-dom`) from the container (network/package registry constraints), so full environment tests were not executed here. 
- Verified app boots locally with `pnpm dev` in the container and captured a smoke screenshot of the login page for visual verification (artifact saved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991b0d7be4483268682e93ab3c3279f)